### PR TITLE
feat: if not active, don't try focusing

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,6 +301,7 @@ function focusTrap(element, userOptions) {
   }
 
   function tryFocus(node) {
+    if (!state.active) return;
     if (node === doc.activeElement) return;
     if (!node || !node.focus) {
       tryFocus(getInitialFocusNode());


### PR DESCRIPTION
Fixing issue where deactivation of focus trap could happen before attempting to focus something again on a delay.

This will fix a problem we are having.  Here is a replication of that problem: https://codesandbox.io/s/upbeat-mendel-kbdzw .