### PR TITLE
feat: Add boolean value support for allowOutsideClick option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Add boolean value support for `allowOutsideClick` option
+
 ## 5.1.0
 
 - Add `setReturnFocus` option that allows you to set which element receives focus when the trap closes.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Returns a new focus trap on `element`.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing.
 - **returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
 - **setReturnFocus** {element|string|function}: By default, focus trap on deactivation will return to the element that was focused before activation. With this option you can specify another element to programmatically receive focus after deactivation. Can be a DOM node, or a selector string (which will be passed to `document.querySelector()` to find the DOM node), or a function that returns a DOM node.
-- **allowOutsideClick** {function}: If set and returns `true`, a click outside the focus trap will not be prevented, even when `clickOutsideDeactivates` is `false`.
+- **allowOutsideClick** {boolean|function}: If set and is or returns `true`, a click outside the focus trap will not be prevented, even when `clickOutsideDeactivates` is `false`.
 - **preventScroll** {boolean}: By default, focus() will scroll to the element if not in viewport. It can produce unattented effects like scrolling back to the top of a modal. If set to `true`, no scroll will happen. 
 
 ### focusTrap.activate([activateOptions])

--- a/demo/index.html
+++ b/demo/index.html
@@ -325,6 +325,10 @@
     <button id="activate-allowoutsideclick">
       activate trap
     </button>
+    <select id="select-allowoutsideclick">
+      <option value="boolean">Boolean</option>
+      <option value="function">Function</option>
+    </select>
   </p>
   <div id="allowoutsideclick" class="trap">
     <p>

--- a/demo/js/allowoutsideclick.js
+++ b/demo/js/allowoutsideclick.js
@@ -3,20 +3,21 @@ var createFocusTrap = require('../../');
 var container = document.getElementById('allowoutsideclick');
 var trigger = document.getElementById('activate-allowoutsideclick');
 var active = false;
+var allowOutsideClick = true;
 
-var focusTrap = createFocusTrap('#allowoutsideclick', {
-  allowOutsideClick: function(event) {
-    if (event.target === trigger) {
-      return true;
+function initialize() {
+  return createFocusTrap('#allowoutsideclick', {
+    allowOutsideClick: allowOutsideClick,
+    onActivate: function() {
+      container.className = 'trap is-active';
+    },
+    onDeactivate: function() {
+      container.className = 'trap';
     }
-  },
-  onActivate: function() {
-    container.className = 'trap is-active';
-  },
-  onDeactivate: function() {
-    container.className = 'trap';
-  }
-});
+  });
+}
+
+var focusTrap = initialize();
 
 function activate() {
   focusTrap.activate();
@@ -42,4 +43,19 @@ document
   .getElementById('deactivate-allowoutsideclick')
   .addEventListener('click', function() {
     deactivate();
+  });
+
+document
+  .getElementById('select-allowoutsideclick')
+  .addEventListener('change', function(event) {
+    allowOutsideClick = {
+      boolean: true,
+      function: function(e) {
+        if (e.target === trigger) {
+          return true;
+        }
+      }
+    }[event.target.value];
+
+    focusTrap = initialize();
   });

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,14 +54,14 @@ declare module 'focus-trap' {
      */
     clickOutsideDeactivates?: boolean;
     /**
-     * If set and returns `true`,
+     * If set and is or returns `true`,
      * a click outside the focus trap will not be prevented,
      * even when `clickOutsideDeactivates` is `false`.
      */
-    allowOutsideClick?: (event: MouseEvent) => boolean;
+    allowOutsideClick?: boolean | (event: MouseEvent) => boolean;
     /**
      * By default, focus() will scroll to the element if not in viewport.
-     * It can produce unattented effects like scrolling back to the top of a modal.
+     * It can produce unintended effects like scrolling back to the top of a modal.
      * If set to `true`, no scroll will happen.
      */
     preventScroll?: boolean;

--- a/index.js
+++ b/index.js
@@ -237,7 +237,12 @@ function focusTrap(element, userOptions) {
     // This is needed for mobile devices.
     // (If we'll only let `click` events through,
     // then on mobile they will be blocked anyways if `touchstart` is blocked.)
-    if (config.allowOutsideClick && config.allowOutsideClick(e)) {
+    if (
+      config.allowOutsideClick &&
+      (typeof config.allowOutsideClick === 'boolean'
+        ? config.allowOutsideClick
+        : config.allowOutsideClick(e))
+    ) {
       return;
     }
     e.preventDefault();
@@ -286,7 +291,12 @@ function focusTrap(element, userOptions) {
   function checkClick(e) {
     if (config.clickOutsideDeactivates) return;
     if (container.contains(e.target)) return;
-    if (config.allowOutsideClick && config.allowOutsideClick(e)) {
+    if (
+      config.allowOutsideClick &&
+      (typeof config.allowOutsideClick === 'boolean'
+        ? config.allowOutsideClick
+        : config.allowOutsideClick(e))
+    ) {
       return;
     }
     e.preventDefault();
@@ -306,7 +316,7 @@ function focusTrap(element, userOptions) {
       tryFocus(getInitialFocusNode());
       return;
     }
-    node.focus({preventScroll: userOptions.preventScroll});
+    node.focus({ preventScroll: userOptions.preventScroll });
     state.mostRecentlyFocusedNode = node;
     if (isSelectableInput(node)) {
       node.select();


### PR DESCRIPTION
## Description

This adds support for boolean value to be passed to the `allowOutsideClick` option. This addresses focus-trap/focus-trap-react#86 and is the follow-up to focus-trap/focus-trap-react#87.

## Considerations

### Documentation

When describing the type of `allowOutsideClick`, I went with "If set and is or returns `true`". There may be a better wording for this.

### Demo

I wanted to add an example without cluttering the page with another example that is visually identical. I opted for a `select` element to switch between passing a function or a boolean. This is contained in ceec9da.