### PR TITLE
ts: fix TypeScript syntax for allowOutsideClick option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ declare module 'focus-trap' {
    * returns a DOM node.
    */
   export type FocusTarget = HTMLElement | string | { (): HTMLElement };
+  
+  type MouseEventToBoolean = (event: MouseEvent) => boolean
 
   export interface Options {
     /**
@@ -58,7 +60,7 @@ declare module 'focus-trap' {
      * a click outside the focus trap will not be prevented,
      * even when `clickOutsideDeactivates` is `false`.
      */
-    allowOutsideClick?: boolean | (event: MouseEvent) => boolean;
+    allowOutsideClick?: boolean | MouseEventToBoolean;
     /**
      * By default, focus() will scroll to the element if not in viewport.
      * It can produce unintended effects like scrolling back to the top of a modal.


### PR DESCRIPTION
[Recent PR](https://github.com/focus-trap/focus-trap/pull/120) contains invalid syntax for new option, this fixes.