### PR TITLE
Package main/module now point to non-minified source

### DIFF
--- a/.changeset/hungry-ducks-itch.md
+++ b/.changeset/hungry-ducks-itch.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Package main/module entries no longer point to minified bundles.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "focus-trap",
   "version": "6.0.0",
   "description": "Trap focus within a DOM node.",
-  "main": "dist/focus-trap.min.js",
-  "module": "dist/focus-trap.esm.min.js",
+  "main": "dist/focus-trap.js",
+  "module": "dist/focus-trap.esm.js",
   "types": "index.d.ts",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
This also means they don't point to bundled source. It's assumed
that these entry points are used by bundlers in end-projects that
will fetch all the necessary external dependencies.