### PR TITLE
Add delayInitialFocus option

### DIFF
--- a/.changeset/wise-terms-heal.md
+++ b/.changeset/wise-terms-heal.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': minor
+---
+
+Add delayInitialFocus option

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+**/*-bundle.js
+dist/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-**/*-bundle.js
-dist/

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Returns a new focus trap on `element`.
 - **allowOutsideClick** {boolean|(e: MouseEvent) => boolean}: If set and is or returns `true`, a click outside the focus trap will not be prevented, even when `clickOutsideDeactivates` is `false`. When `clickOutsideDeactivates` is `true`, this option is **ignored** (i.e. if it's a function, it will not be called). Use this option to control if (and even which) clicks are allowed outside the trap in conjunction with `clickOutsideDeactivates: false`.
 - **returnFocusOnDeactivate** {boolean}: Default: `true`. If `false`, when the trap is deactivated, focus will *not* return to the element that had focus before activation.
 - **setReturnFocus** {element|string|function}: By default, focus trap on deactivation will return to the element that was focused before activation. With this option you can specify another element to programmatically receive focus after deactivation. Can be a DOM node, or a selector string (which will be passed to `document.querySelector()` to find the DOM node), or a function that returns a DOM node.
-- **preventScroll** {boolean}: By default, focus() will scroll to the element if not in viewport. It can produce unintended effects like scrolling back to the top of a modal. If set to `true`, no scroll will happen. 
+- **preventScroll** {boolean}: By default, focus() will scroll to the element if not in viewport. It can produce unintended effects like scrolling back to the top of a modal. If set to `true`, no scroll will happen.
+- **delayInitialFocus** {boolean}: Default: `true`. Delays the autofocus when the focus trap is activated. This prevents elements within the focusable element from capturing the event that triggered the focus trap activation.
 
 ### focusTrap.activate([activateOptions])
 

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -230,7 +230,35 @@ describe('focus-trap', () => {
   });
 
   describe('demo: delay', () => {
-    // TODO
+    it('activates the focus trap when delayInitialFocus is set to true', () => {
+      cy.get('#delay').should(($div) => {
+        expect($div[0].style.opacity).to.equal('0.2');
+      });
+      cy.get('#activate-delay').type('{enter}');
+      cy.get('#delay').should('have.class', 'trap is-active');
+      cy.get('#delay').should(($div) => {
+        expect($div[0].style.opacity).to.equal('1');
+      });
+      cy.get('#close-button-delay').as('focusedEl').should('have.focus');
+
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@focusedEl');
+    });
+
+    it('activates the focus trap when delayInitialFocus is set to false', () => {
+      cy.get('#no-delay').should(($div) => {
+        expect($div[0].style.opacity).to.equal('0.2');
+      });
+      cy.get('#activate-no-delay').type('{enter}');
+      cy.get('#no-delay').should('have.class', 'trap is-active');
+      cy.get('#no-delay').should(($div) => {
+        expect($div[0].style.opacity).to.equal('1');
+      });
+      cy.get('#close-button-no-delay').as('focusedEl').should('have.focus');
+
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@focusedEl');
+    });
   });
 
   describe('demo: radio', () => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -285,6 +285,27 @@
     </div>
   </div>
 
+
+  <div id="demo-no-delay">
+    <h2 id="delay-heading-explicit">No delay</h2>
+    <p>
+      focus-trap ensure that the placement of focus within the trap is not delayed, so the focused element captures the event that originated the activation of the focus trap.
+    </p>
+    <p>
+      <button id="activate-no-delay">
+        Reveal by pressing Enter
+      </button>
+    </p>
+
+    <div id="no-delay" class="trap" style="opacity: 0.2;">
+      <p>
+        <button id="close-button-no-delay">
+          Hide
+        </button>
+      </p>
+    </div>
+  </div>
+
   <div id="demo-radio">
     <h2 id="radio-heading">radio group</h2>
     <p>

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -12,3 +12,4 @@ require('./iframe');
 require('./allow-outside-click');
 require('./click-outside-deactivates');
 require('./set-return-focus');
+require('./no-delay');

--- a/demo/js/no-delay.js
+++ b/demo/js/no-delay.js
@@ -1,0 +1,33 @@
+var { createFocusTrap } = require('../../dist/focus-trap');
+
+var container = document.getElementById('no-delay');
+
+var focusTrap = createFocusTrap(container, {
+  delayInitialFocus: false,
+  onActivate() {
+    container.style.opacity = '1';
+    container.classList.add('is-active');
+  },
+  onDeactivate() {
+    container.style.opacity = '0.2';
+    container.classList.remove('is-active');
+  },
+});
+
+document
+  .getElementById('activate-no-delay')
+  .addEventListener('keydown', showContainer);
+document
+  .getElementById('close-button-no-delay')
+  .addEventListener('click', hideContainer);
+
+function showContainer(e) {
+  if (e.keyCode === 13) {
+    e.preventDefault();
+    focusTrap.activate();
+  }
+}
+
+function hideContainer() {
+  focusTrap.deactivate();
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,12 @@ declare module 'focus-trap' {
      * If set to `true`, no scroll will happen.
      */
     preventScroll?: boolean;
+    /**
+     * Default: `true`. Delays the autofocus when the focus trap is activated.
+     * This prevents elements within the focusable element from capturing
+     * the event that triggered the focus trap activation.
+     */
+    delayInitialFocus?: boolean;
   }
 
   type ActivateOptions = Pick<Options, 'onActivate'>;

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function createFocusTrap(element, userOptions) {
   var config = {
     returnFocusOnDeactivate: true,
     escapeDeactivates: true,
+    delayInitialFocus: true,
     ...userOptions,
   };
 
@@ -139,9 +140,11 @@ function createFocusTrap(element, userOptions) {
 
     // Delay ensures that the focused element doesn't capture the event
     // that caused the focus trap activation.
-    activeFocusDelay = delay(function () {
-      tryFocus(getInitialFocusNode());
-    });
+    activeFocusDelay = config.delayInitialFocus
+      ? delay(function () {
+          tryFocus(getInitialFocusNode());
+        })
+      : tryFocus(getInitialFocusNode());
 
     doc.addEventListener('focusin', checkFocusIn, true);
     doc.addEventListener('mousedown', checkPointerDown, {


### PR DESCRIPTION
A change was introduce to add delay before autofocus in this PR https://github.com/focus-trap/focus-trap/pull/51 . The example given was https://codepen.io/anon/pen/RyvdEZ?editors=1111. Looking at the example, the bug described in the issue is not a `focus-trap` bug. 

The desired effect @pgn-vole was hopping to achieve could be done by calling `e.preventDefault()` on the event handler on the example instead of using `setTimeout`.

This change has not allowed us to upgrade to the latest version `6.0.1` because the behaviour of `createFocusTrap` changed without any additional documentation.

We are using this awesome library in the [atom text editor](https://github.com/atom/atom/pull/21256) 


###  Features and Bug Fixes

- [x] Issue being fixed is referenced.
~- [] Test coverage added/updated.~
~- [ ] Typings added/updated.~
~- [ ] README updated (API changes, instructions, etc.).~
~- [ ] Changes to dependencies explained.~
~- [ ] Changeset added (run `yarn changeset` locally to add one, follow prompts).~

👉 If any of these don't apply, please ~cross them out~.

### Tooling

~- [ ] Issue being fixed is referenced.~
~- [ ] Changes to dependencies explained.~
~- [ ] README instructions updated.~
~- [ ] A Changeset is __not__ added.~

👉 If any of these don't apply, please ~cross them out~.
