### PR TITLE
Respect returnFocusOnDeactivate when deactivating trap

### DIFF
--- a/.changeset/loud-countries-sit.md
+++ b/.changeset/loud-countries-sit.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Fixed #103: `returnFocusOnDeactivate` is now respected on auto-deactivation with `clickOutsideDeactivates=true`.

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -274,7 +274,119 @@ describe('focus-trap', () => {
   });
 
   describe('demo: clickoutsidedeactivates', () => {
-    // TODO
+    const activateTrap = function () {
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+    };
+
+    const checkTrap = function () {
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
+
+      // trap is active (keep focus in trap by tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap')
+        .tab()
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab()
+        .as('lastElementInTrap')
+        .should('contain', 'nothing')
+        .should('be.focused')
+        .tab();
+
+      // trap is active (keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
+      cy.get('@lastElementInTrap').should('be.focused');
+    };
+
+    it('traps focus, deactivates on outside click on checkbox and checkbox focused, returnFocusOnDeactivate=true', () => {
+      cy.get('#demo-clickoutsidedeactivates').as('testRoot');
+
+      // set returnFocusOnDeactivate=TRUE
+      cy.get('#select-returnfocusondeactivate-clickoutsidedeactivates').select(
+        'true'
+      );
+
+      activateTrap();
+      checkTrap();
+
+      // deactivate trap by toggling FOCUSABLE checkbox
+      cy.get('#checkbox-clickoutsidedeactivates').click();
+      cy.get('#checkbox-clickoutsidedeactivates').should('be.checked');
+
+      // implies trap no longer active since checkbox is outside trap
+      cy.get('#checkbox-clickoutsidedeactivates').should('be.focused');
+
+      cy.get('@lastElementInTrap').should('not.be.focused');
+    });
+
+    it('traps focus, deactivates on outside click on document and "activate trap" button focused', () => {
+      cy.get('#demo-clickoutsidedeactivates').as('testRoot');
+
+      // set returnFocusOnDeactivate=TRUE
+      cy.get('#select-returnfocusondeactivate-clickoutsidedeactivates').select(
+        'true'
+      );
+
+      activateTrap();
+      checkTrap();
+
+      // deactivate trap by clicking NON-focusable element
+      cy.get('#clickoutsidedeactivates-heading').click();
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
+
+      cy.get('@lastElementInTrap').should('not.be.focused');
+    });
+
+    it('traps focus, deactivates on outside click on checkbox and checkbox focused, returnFocusOnDeactivate=false', () => {
+      cy.get('#demo-clickoutsidedeactivates').as('testRoot');
+
+      // set returnFocusOnDeactivate=FALSE
+      cy.get('#select-returnfocusondeactivate-clickoutsidedeactivates').select(
+        'false'
+      );
+
+      activateTrap();
+      checkTrap();
+
+      // deactivate trap by toggling FOCUSABLE checkbox
+      cy.get('#checkbox-clickoutsidedeactivates').click();
+      cy.get('#checkbox-clickoutsidedeactivates').should('be.checked');
+
+      // implies trap no longer active since checkbox is outside trap
+      cy.get('#checkbox-clickoutsidedeactivates').should('be.focused');
+
+      cy.get('@lastElementInTrap').should('not.be.focused');
+    });
+
+    it('traps focus, deactivates on outside click on document, and nothing is focused', () => {
+      cy.get('#demo-clickoutsidedeactivates').as('testRoot');
+
+      // set returnFocusOnDeactivate=FALSE
+      cy.get('#select-returnfocusondeactivate-clickoutsidedeactivates').select(
+        'false'
+      );
+
+      activateTrap();
+      checkTrap();
+
+      // deactivate trap by clicking NON-focusable element
+      cy.get('#clickoutsidedeactivates-heading').click();
+
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should(
+        'not.be.focused'
+      );
+      cy.get('@lastElementInTrap').should('not.be.focused');
+      cy.get('*:focus').should('not.exist'); // nothing has focus
+    });
   });
 
   describe('demo: setreturnfocus', () => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -285,7 +285,6 @@
     </div>
   </div>
 
-
   <div id="demo-no-delay">
     <h2 id="delay-heading-explicit">No delay</h2>
     <p>
@@ -398,12 +397,29 @@
       This focus trap can be closed simply by <strong>clicking anywhere outside</strong>, and the click outside will also go through and do what it was intentionally dispatched to do (like toggling the checkbox). ESC is <strong>disabled</strong> for this trap.
     </p>
     <p>
+      The <code>returnFocusOnDeactivate</code> option controls whether focus should be returned to the last-focused element when the trap was activated (the "activate trap" button) or not -- IIF what you click on outside the trap is <strong>not</strong> focusable:
+    </p>
+    <ul>
+      <li>If this option is <code>true</code> (the default behavior) but you click on a focusable node outside the trap (like the checkbox), the click will go through, the checkbox will be toggled, and focus will remain on the checkbox.</li>
+      <li>If <code>true</code> but you click on something <strong>not</strong> focusable (like the page/document), then focus will return to the "activate trap" button (since that was the last-focused node before the trap was activate).</li>
+      <li>If <code>false</code>, then it doesn't matter what you click on (focusable or not), focus will go away from the trap to where you clicked, or to nowhere if you clicked on something not focusable (like the page/document).</li>
+    </ul>
+    <p>
       <button id="activate-clickoutsidedeactivates">
         activate trap
       </button>
       <label>
-        Toggling me deactivates (but doesn't know about the trap):
-        <input type="checkbox" />
+        Set <code>returnFocusOnDeactivate</code> as:
+        <select id="select-returnfocusondeactivate-clickoutsidedeactivates">
+          <option value="true">true</option><!-- default -->
+          <option value="false">false</option>
+        </select>
+      </label>
+    </p>
+    <p>
+      <label>
+        Toggling me causes auto-deactivation of the trap:
+        <input type="checkbox" id="checkbox-clickoutsidedeactivates" />
       </label>
     </p>
     <div id="clickoutsidedeactivates" class="trap">

--- a/demo/js/click-outside-deactivates.js
+++ b/demo/js/click-outside-deactivates.js
@@ -1,28 +1,41 @@
-var { createFocusTrap } = require('../../dist/focus-trap');
+const { createFocusTrap } = require('../../dist/focus-trap');
 
-var container = document.getElementById('clickoutsidedeactivates');
-var trigger = document.getElementById('activate-clickoutsidedeactivates');
-var active = false;
+const container = document.getElementById('clickoutsidedeactivates');
+const trigger = document.getElementById('activate-clickoutsidedeactivates');
+let active = false;
+let returnFocusOnDeactivate = true;
 
-const focusTrap = createFocusTrap('#clickoutsidedeactivates', {
-  clickOutsideDeactivates: true,
-  escapeDeactivates: false,
-  onActivate: function () {
-    container.className = 'trap is-active';
-  },
-  onDeactivate: function () {
-    active = false;
-    container.className = 'trap';
-  },
-});
+const initialize = function () {
+  return createFocusTrap('#clickoutsidedeactivates', {
+    returnFocusOnDeactivate,
+    clickOutsideDeactivates: true,
+    escapeDeactivates: false,
+    onActivate: function () {
+      container.className = 'trap is-active';
+    },
+    onDeactivate: function () {
+      active = false;
+      container.className = 'trap';
+    },
+  });
+};
 
-function activate() {
+const activate = function () {
   active = true;
   focusTrap.activate();
-}
+};
+
+let focusTrap = initialize();
 
 trigger.addEventListener('click', function () {
   if (!active) {
     activate();
   }
 });
+
+document
+  .getElementById('select-returnfocusondeactivate-clickoutsidedeactivates')
+  .addEventListener('change', function (event) {
+    returnFocusOnDeactivate = event.target.value === 'true';
+    focusTrap = initialize();
+  });

--- a/index.js
+++ b/index.js
@@ -227,13 +227,30 @@ function createFocusTrap(element, userOptions) {
   // This needs to be done on mousedown and touchstart instead of click
   // so that it precedes the focus event.
   function checkPointerDown(e) {
-    if (container.contains(e.target)) return;
+    if (container.contains(e.target)) {
+      // allow the click since it ocurred inside the trap
+      return;
+    }
+
     if (config.clickOutsideDeactivates) {
+      // immediately deactivate the trap
       deactivate({
-        returnFocus: !isFocusable(e.target),
+        // if, on deactivation, we should return focus to the node originally-focused
+        //  when the trap was activated (or the configured `setReturnFocus` node),
+        //  then assume it's also OK to return focus to the outside node that was
+        //  just clicked, causing deactivation, as long as that node is focusable;
+        //  if it isn't focusable, then return focus to the original node focused
+        //  on activation (or the configured `setReturnFocus` node)
+        // NOTE: by setting `returnFocus: false`, deactivate() will do nothing,
+        //  which will result in the outside click setting focus to the node
+        //  that was clicked, whether it's focusable or not; by setting
+        //  `returnFocus: true`, we'll attempt to re-focus the node originally-focused
+        //  on activation (or the configured `setReturnFocus` node)
+        returnFocus: config.returnFocusOnDeactivate && !isFocusable(e.target),
       });
       return;
     }
+
     // This is needed for mobile devices.
     // (If we'll only let `click` events through,
     // then on mobile they will be blocked anyways if `touchstart` is blocked.)
@@ -243,8 +260,11 @@ function createFocusTrap(element, userOptions) {
         ? config.allowOutsideClick
         : config.allowOutsideClick(e))
     ) {
+      // allow the click outside the trap to take place
       return;
     }
+
+    // otherwise, prevent the click
     e.preventDefault();
   }
 


### PR DESCRIPTION
Fixes #103

The flag wasn't being respected when the trap is deactivated as
a result of `clickOutsideDeactivates=true` option.

###  Features and Bug Fixes

- [x] Issue being fixed is referenced.
- [x] Test coverage added/updated.
- [ ] ~Typings added/updated.~
- [ ] ~README updated (API changes, instructions, etc.).~
- [ ] ~Changes to dependencies explained.~
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).
