### PR TITLE
Bump tabbable dependency to 5.1.1

### DIFF
--- a/.changeset/stale-carpets-decide.md
+++ b/.changeset/stale-carpets-decide.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Update tabbable dependency to 5.1.1 to get transpiled non-minified bundles.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://github.com/focus-trap/focus-trap#readme",
   "dependencies": {
-    "tabbable": "^5.1.0"
+    "tabbable": "^5.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6398,10 +6398,10 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
-tabbable@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.0.tgz#b81115168d0a8359ba69003b6a99d05f8480a664"
-  integrity sha512-Y3nSukchqM5UchuZjhj/WyE79Qb4RM/Vx3x3oHO3UYKKpf70Hy3iVRxb61MzCavN74aZsKzvPl4KNG8tQUAjFQ==
+tabbable@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.1.tgz#33d6950a615bc78c6eb6828f3953e66544817dc4"
+  integrity sha512-qjkrV7I29Lkg///jPQnq26+26q9wQOKTEcckrwPejTsxxl2zdK60x0XmiEELCEParLhgbVQRflyKkpr+K/SmCQ==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
That version of tabbable has transpiled non-minified bundles, which
will help with #172.
