### PR TITLE
Bump tabbable to 5.1.2

### DIFF
--- a/.changeset/dull-wolves-change.md
+++ b/.changeset/dull-wolves-change.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Close the gap with #172 and bump `tabbable` to 5.1.2 which has a similar fix.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://github.com/focus-trap/focus-trap#readme",
   "dependencies": {
-    "tabbable": "^5.1.1"
+    "tabbable": "^5.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6398,10 +6398,10 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
-tabbable@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.1.tgz#33d6950a615bc78c6eb6828f3953e66544817dc4"
-  integrity sha512-qjkrV7I29Lkg///jPQnq26+26q9wQOKTEcckrwPejTsxxl2zdK60x0XmiEELCEParLhgbVQRflyKkpr+K/SmCQ==
+tabbable@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.2.tgz#3c4eac2901d0000913d13ce147229eb1405b59ca"
+  integrity sha512-DNmnX4XgkjK7kxDnQ5IbyYoNke2izMk5b62All0qxzoCF3wE7H9CuZ2IPdfAN8v79E0rpjv2k78uWuIXupGa9g==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
To help close the gap with #172, bump the version since it has a
similar fix to tabbable.