### PR TITLE
Allow trap containers to have no tabbable nodes

### DIFF
--- a/.changeset/slimy-ducks-whisper.md
+++ b/.changeset/slimy-ducks-whisper.md
@@ -2,4 +2,4 @@
 'focus-trap': patch
 ---
 
-Fix a bug where a multi-container trap would cease to work if all tabbable nodes were removed from one of the containers (fixes #223). As a result, an error is now thrown if the trap is left in a state where none of its containers contain any tabbable nodes (unless a `fallbackFocus` node has been configured in the trap's options).
+Fix a bug where a multi-container trap would cease to work if all tabbable nodes were removed from one of the containers (fixes #223). As a result, an error is now thrown if the trap is left in a state where none of its containers contain any tabbable nodes (unless a `fallbackFocus` node has been configured in the trap's options). Also, the most-recently-focused node is more reliably tracked now, should focus somehow escape the trap and be brought back in by the trap, resulting in the truly most-recently-focused node to regain focus if that ever happens.

--- a/.changeset/slimy-ducks-whisper.md
+++ b/.changeset/slimy-ducks-whisper.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Fix a bug where a multi-container trap would cease to work if all tabbable nodes were removed from one of the containers (fixes #223). As a result, an error is now thrown if the trap is left in a state where none of its containers contain any tabbable nodes (unless a `fallbackFocus` node has been configured in the trap's options).

--- a/README.md
+++ b/README.md
@@ -59,19 +59,21 @@ const { createFocusTrap } = require('focus-trap'); // CJS
 focusTrap = createFocusTrap(element[, createOptions]);
 ```
 
-Returns a new focus trap on `element`.
+Returns a new focus trap on `element` (one or more "containers" of tabbable nodes that, together, form the total set of nodes that can be visited, with clicks or the tab key, within the trap).
 
 `element` can be
-- a DOM node (the focus trap itself) or
-- a selector string (which will be passed to `document.querySelector()` to find the DOM node) or
+- a DOM node (the focus trap itself);
+- a selector string (which will be passed to `document.querySelector()` to find the DOM node); or
 - an array of DOM nodes or selector strings (where the order determines where the focus will go after the last tabbable element of a DOM node/selector is reached).
+
+> A focus trap must have at least one container with at least one tabbable/focusable node in it to be considered valid. While nodes can be added/removed at runtime, with the trap adjusting to added/removed tabbable nodes, __an error will be thrown__ if the trap ever gets into a state where it determines none of its containers have any tabbable nodes in them _and_ the `fallbackFocus` option does not resolve to an alternate node where focus can go.
 
 `createOptions`:
 
 - **onActivate** {function}: A function that will be called when the focus trap activates.
 - **onDeactivate** {function}: A function that will be called when the focus trap deactivates,
 - **initialFocus** {element|string|function}: By default, when a focus trap is activated the first element in the focus trap's tab order will receive focus. With this option you can specify a different element to receive that initial focus. Can be a DOM node, or a selector string (which will be passed to `document.querySelector()` to find the DOM node), or a function that returns a DOM node.
-- **fallbackFocus** {element|string|function}: By default, an error will be thrown if the focus trap contains no elements in its tab order. With this option you can specify a fallback element to programmatically receive focus if no other tabbable elements are found. For example, you may want a popover's `<div>` to receive focus if the popover's content includes no tabbable elements. *Make sure the fallback element has a negative `tabindex` so it can be programmatically focused.* The option value can be a DOM node, a selector string (which will be passed to `document.querySelector()` to find the DOM node), or  a function that returns a DOM node.
+- **fallbackFocus** {element|string|function}: By default, an error will be thrown if the focus trap contains no elements in its tab order. With this option you can specify a fallback element to programmatically receive focus if no other tabbable elements are found. For example, you may want a popover's `<div>` to receive focus if the popover's content includes no tabbable elements. *Make sure the fallback element has a negative `tabindex` so it can be programmatically focused.* The option value can be a DOM node, a selector string (which will be passed to `document.querySelector()` to find the DOM node), or a function that returns a DOM node.
 - **escapeDeactivates** {boolean}: Default: `true`. If `false`, the `Escape` key will not trigger deactivation of the focus trap. This can be useful if you want to force the user to make a decision instead of allowing an easy way out.
 - **clickOutsideDeactivates** {boolean}: Default: `false`. If `true`, a click outside the focus trap will deactivate the focus trap and allow the click event to do its thing. This option **takes precedence** over `allowOutsideClick` when it's set to `true`.
 - **allowOutsideClick** {boolean|(e: MouseEvent) => boolean}: If set and is or returns `true`, a click outside the focus trap will not be prevented, even when `clickOutsideDeactivates` is `false`. When `clickOutsideDeactivates` is `true`, this option is **ignored** (i.e. if it's a function, it will not be called). Use this option to control if (and even which) clicks are allowed outside the trap in conjunction with `clickOutsideDeactivates: false`.

--- a/demo/index.html
+++ b/demo/index.html
@@ -490,6 +490,69 @@
     </div>
   </div>
 
+  <div id="demo-multipleelements-delete">
+    <h2 id="multipleelements-delete-heading">multiple elements with delete</h2>
+    <p>
+      Pass multiple elements. Update the tabbable nodes in any of those elements
+      on the fly, ensuring there's always at least one container with at least
+      one tabbable node in it at all times.
+    </p>
+    <p>
+      <button id="activate-multipleelements-delete">
+        activate trap
+      </button>
+    </p>
+    <div id="multipleelements-delete" class="trap">
+      <div id="multipleelements-delete-1">
+        <p style="margin-top: 0">Container 1</p>
+        <button id="multipleelements-delete-removed-node">Gets removed</button>
+      </div>
+      <div id="multipleelements-delete-2">
+        <p>Container 2</p>
+        <button id="multipleelements-delete-remove">Remove button</button>
+        <a href="#">Some</a>
+        <a href="#">other</a>
+        <a href="#">focusable</a> parts.
+      </div>
+      <div>
+        <p>Not in trap (clicks allowed)</p>
+        <button id="deactivate-multipleelements-delete">
+          deactivate trap
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div id="demo-multipleelements-delete-all">
+    <h2 id="multipleelements-delete-all-heading">multiple elements with delete ALL</h2>
+    <p>
+      Pass multiple elements. With the <strong>fallbackFocus</strong> option configured
+      to the "deactivate trap" button, remove ALL nodes in all trap containers to have
+      the focus <em>fall back</em> to the "deactivate" button on the next tab key press.
+    </p>
+    <p>
+      <button id="activate-multipleelements-delete-all">
+        activate trap
+      </button>
+    </p>
+    <div id="multipleelements-delete-all" class="trap">
+      <div id="multipleelements-delete-all-1">
+        <p style="margin-top: 0">Container 1</p>
+        <button id="multipleelements-delete-all-removed-node">Gets removed</button>
+      </div>
+      <div id="multipleelements-delete-all-2">
+        <p>Container 2</p>
+        <button id="multipleelements-delete-all-remove">Remove all button</button>
+      </div>
+      <div>
+        <p>Not in trap (fallback; clicks allowed)</p>
+        <button id="deactivate-multipleelements-delete-all">
+          deactivate trap
+        </button>
+      </div>
+    </div>
+  </div>
+
   <div id="demo-multipleelements-multipletraps">
     <h2 id="multipleelements-multipletraps-heading">multiple traps with multiple elements</h2>
     <p>
@@ -506,7 +569,7 @@
       </button>
     </p>
     <div id="multipleelements-multipletraps" class="trap">
-      <p id="multipleelements-multipletraps-1">
+      <p id="multipleelements-multipletraps-1" style="margin-top: 0">
         Here is a focus trap <a href="#">with</a> <a href="#">some</a>
         <a href="#">focusable</a> parts.
       </p>

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -14,4 +14,6 @@ require('./click-outside-deactivates');
 require('./set-return-focus');
 require('./no-delay');
 require('./multiple-elements');
+require('./multiple-elements-delete');
+require('./multiple-elements-delete-all');
 require('./multiple-traps-multiple-elements');

--- a/demo/js/multiple-elements-delete-all.js
+++ b/demo/js/multiple-elements-delete-all.js
@@ -1,0 +1,48 @@
+const { createFocusTrap } = require('../../dist/focus-trap');
+
+const container = document.getElementById('multipleelements-delete-all');
+const selectors = [
+  '#multipleelements-delete-all-1',
+  '#multipleelements-delete-all-2',
+];
+
+const focusTrap = createFocusTrap(selectors, {
+  fallbackFocus: '#deactivate-multipleelements-delete-all',
+  allowOutsideClick(event) {
+    return event.target.id === 'deactivate-multipleelements-delete-all';
+  },
+  onActivate: function () {
+    container.className = 'trap is-active';
+    selectors.forEach(
+      (selector) =>
+        (document.querySelector(selector).className = 'is-active-nested')
+    );
+  },
+  onDeactivate: function () {
+    container.className = 'trap';
+    selectors.forEach(
+      (selector) => (document.querySelector(selector).className = null)
+    );
+  },
+});
+
+document
+  .getElementById('activate-multipleelements-delete-all')
+  .addEventListener('click', function () {
+    focusTrap.activate();
+  });
+
+document
+  .getElementById('deactivate-multipleelements-delete-all')
+  .addEventListener('click', function () {
+    focusTrap.deactivate();
+  });
+
+document
+  .getElementById('multipleelements-delete-all-remove')
+  .addEventListener('click', function (event) {
+    document
+      .getElementById('multipleelements-delete-all-removed-node')
+      .remove();
+    event.target.remove();
+  });

--- a/demo/js/multiple-elements-delete.js
+++ b/demo/js/multiple-elements-delete.js
@@ -1,0 +1,41 @@
+const { createFocusTrap } = require('../../dist/focus-trap');
+
+const container = document.getElementById('multipleelements-delete');
+const selectors = ['#multipleelements-delete-1', '#multipleelements-delete-2'];
+
+const focusTrap = createFocusTrap(selectors, {
+  allowOutsideClick(event) {
+    return event.target.id === 'deactivate-multipleelements-delete';
+  },
+  onActivate: function () {
+    container.className = 'trap is-active';
+    selectors.forEach(
+      (selector) =>
+        (document.querySelector(selector).className = 'is-active-nested')
+    );
+  },
+  onDeactivate: function () {
+    container.className = 'trap';
+    selectors.forEach(
+      (selector) => (document.querySelector(selector).className = null)
+    );
+  },
+});
+
+document
+  .getElementById('activate-multipleelements-delete')
+  .addEventListener('click', function () {
+    focusTrap.activate();
+  });
+
+document
+  .getElementById('deactivate-multipleelements-delete')
+  .addEventListener('click', function () {
+    focusTrap.deactivate();
+  });
+
+document
+  .getElementById('multipleelements-delete-remove')
+  .addEventListener('click', function () {
+    document.getElementById('multipleelements-delete-removed-node').remove();
+  });

--- a/index.js
+++ b/index.js
@@ -235,9 +235,10 @@ const createFocusTrap = function (elements, userOptions) {
 
   // In case focus escapes the trap for some strange reason, pull it back in.
   const checkFocusIn = function (e) {
+    const targetContained = containersContain(e.target);
     // In Firefox when you Tab out of an iframe the Document is briefly focused.
-    if (containersContain(e.target) || e.target instanceof Document) {
-      if (containersContain(e.target)) {
+    if (targetContained || e.target instanceof Document) {
+      if (targetContained) {
         state.mostRecentlyFocusedNode = e.target;
       }
     } else {


### PR DESCRIPTION
Fixes #223 and adds an exception thrown if the trap is allowed to get into a state where none of its containers contain any tabbable nodes (there must always be at least one container that has at least one tabbable node among all containers configured) -- unless the `fallbackFocus` option has been configured to provide a fallback node.

- [x] Add test coverage
- [x] Add changeset