### PR TITLE
Fix focus escape when press TAB after hiding element with focus

### DIFF
--- a/.changeset/old-bottles-notice.md
+++ b/.changeset/old-bottles-notice.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Fix a focus escape when pressing TAB after hiding element with focus (#281)

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -207,11 +207,12 @@ describe('focus-trap', () => {
   });
 
   describe('demo: ht', () => {
+    // hidden treasures
     beforeEach(() => {
       cy.get('#demo-ht').as('testRoot');
     });
 
-    it('focusing on only visually available(display is not "none" and visibility is not "hidden") elements', () => {
+    it('focusing on only visually available (display is not "none" and visibility is not "hidden") elements', () => {
       // activate trap
       cy.get('@testRoot')
         .findByRole('button', { name: /^activate trap/ })
@@ -234,6 +235,11 @@ describe('focus-trap', () => {
         .as('focusedElInTrap');
 
       verifyCrucialFocusTrapOnClicking('@focusedElInTrap');
+
+      cy.get('@focusedElInTrap').focus();
+      cy.focused().type('{enter}'); // buttons 3 and 4 will disappear, leaving body focused
+      cy.tab(); // forward TAB should then focus first element in first tabbable group
+      cy.get('@firstTabbableElInTrap').should('be.focused');
 
       // focus can be transitioned freely when trap is deactivated
       cy.focused().type('{esc}');


### PR DESCRIPTION
Fixes #281

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
