### PR TITLE
Fix inability to select radios in selectable container with selected text

### DIFF
--- a/.changeset/happy-rules-flow.md
+++ b/.changeset/happy-rules-flow.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Fix bug on Chrome where radio button cannot be selected when it is in a trap that is located in a focusable container that has selected text content at the time the trap is activated ([#313](https://github.com/focus-trap/focus-trap/issues/313)).

--- a/demo/index.html
+++ b/demo/index.html
@@ -603,6 +603,39 @@
       </div>
     </div>
 
+    <div id="demo-textfocusradiobug">
+      <h2 id="textfocusradiobug-heading">text focus bug</h2>
+      <div id="textfocusradiobug-main" tabindex="-1">
+        <button id="activate-textfocusradiobug">activate trap</button>
+        <p>
+          This is a test for <a href="https://github.com/focus-trap/focus-trap/issues/313">issue 313</a>
+          where selecting <span id="content-textfocusradiobug">some of this text</span> <em>prior</em>
+          to activating the trap <strong>on Chrome</strong> will prevent the ability to select any of
+          the radio buttons &mdash; unless the document&apos;s selection is cleared while activating
+          the trap (which is what we now do).
+        </p>
+        <div id="textfocusradiobug" class="trap">
+          <div>
+            <label>
+              <input type="radio" id="textfocusradiobug-huey" name="drone" value="huey" checked>
+              Huey
+            </label>
+          </div>
+          <div>
+            <input type="radio" id="textfocusradiobug-dewey" name="drone" value="dewey">
+            <label for="textfocusradiobug-dewey">Dewey</label>
+          </div>
+          <div>
+            <input type="radio" id="textfocusradiobug-louie" name="drone" value="louie">
+            <label for="textfocusradiobug-louie">Louie</label>
+          </div>
+          <input type="text" />
+          <br />
+          <button id="deactivate-textfocusradiobug">deactivate trap</button>
+        </div>
+      </div>
+    </div>
+
     <p>
       <span aria-hidden="true" style="font-size:2em;vertical-align:middle;">☜</span>
       <a href="https://github.com/focus-trap/focus-trap" style="vertical-align:middle;">Return to the repository</a>

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -17,3 +17,4 @@ require('./multiple-elements');
 require('./multiple-elements-delete');
 require('./multiple-elements-delete-all');
 require('./multiple-traps-multiple-elements');
+require('./text-focus-radio-bug');

--- a/demo/js/text-focus-radio-bug.js
+++ b/demo/js/text-focus-radio-bug.js
@@ -1,0 +1,23 @@
+const { createFocusTrap } = require('../../dist/focus-trap');
+
+const container = document.getElementById('textfocusradiobug');
+const trigger = document.getElementById('activate-textfocusradiobug');
+const deactivateTrigger = document.getElementById(
+  'deactivate-textfocusradiobug'
+);
+
+const focusTrap = createFocusTrap(container, {
+  escapeDeactivates: false,
+  onActivate: function () {
+    container.className = 'trap is-active';
+  },
+  onDeactivate: function () {
+    container.className = 'trap';
+  },
+});
+
+trigger.addEventListener('click', focusTrap.activate.bind(focusTrap));
+deactivateTrigger.addEventListener(
+  'click',
+  focusTrap.deactivate.bind(focusTrap)
+);

--- a/index.js
+++ b/index.js
@@ -427,6 +427,22 @@ const createFocusTrap = function (elements, userOptions) {
     return trap;
   };
 
+  const removeDocSelection = function () {
+    // remove any current selection in the document to make sure, especially on Chrome,
+    //  that radio buttons are selectable if present, the trap is in a focusable
+    //  container, and the container has a text selection
+    // @see https://github.com/focus-trap/focus-trap/issues/313 for more context
+    // @ref https://stackoverflow.com/questions/3169786/clear-text-selection-with-javascript
+    // @ref https://developer.mozilla.org/en-US/docs/Web/API/Selection#browser_compatibility
+    const selection =
+      typeof document.getSelection === 'function'
+        ? document.getSelection()
+        : document.selection;
+    if (selection && typeof selection.empty === 'function') {
+      selection.empty();
+    }
+  };
+
   //
   // TRAP DEFINITION
   //
@@ -451,6 +467,7 @@ const createFocusTrap = function (elements, userOptions) {
         onActivate();
       }
 
+      removeDocSelection();
       addListeners();
       return this;
     },


### PR DESCRIPTION
Fixes #313

Since document selection, if any, gets automatically cleared by the browser
on Safari and FireFox, programmatically clearing it on Chrome should be OK
since that technically makes the behavior more consistent across browsers.

This code _should_ work fine on IE as well, though I have no means of
testing it on that browser. I'm going by the Stack Overflow article
I referenced in the code changes.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
