### PR TITLE
Fix focus stuck on tabindex=-1 container with shift+tab

### DIFF
--- a/.changeset/stupid-snakes-complain.md
+++ b/.changeset/stupid-snakes-complain.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Fix focus trapped on initial focus container with tabindex=-1 when pressing shift+tab (#363)


### PR DESCRIPTION
Fixes #363

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
