### PR TITLE
[#441] Fix race delayed initial focus race condition

### DIFF
--- a/.changeset/little-melons-remember.md
+++ b/.changeset/little-melons-remember.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Fix race condition when activating a second trap where initial focus in the second trap may be thwarted because pausing of first trap clears the `delayInitialFocus` timer created for the second trap before during its activation sequence.

--- a/docs/demo-bundle.js
+++ b/docs/demo-bundle.js
@@ -916,7 +916,9 @@ const focusTrap = createFocusTrap('#escape-deactivates', {
   escapeDeactivates: () => escapeDeactivatesOption.checked,
 
   // allow clicking on the checkbox or its label since it's outside the trap
-  allowOutsideClick: (e) => e.target === escapeDeactivatesOption || e.target === escapeDeactivatesOption.parentNode,
+  allowOutsideClick: (e) =>
+    e.target === escapeDeactivatesOption ||
+    e.target === escapeDeactivatesOption.parentNode,
 });
 
 document

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 import { tabbable, isFocusable } from 'tabbable';
 
-let activeFocusDelay;
-
 const activeFocusTraps = (function () {
   const trapQueue = [];
   return {
@@ -111,6 +109,10 @@ const createFocusTrap = function (elements, userOptions) {
     mostRecentlyFocusedNode: null,
     active: false,
     paused: false,
+
+    // timer ID for when delayInitialFocus is true and initial focus in this trap
+    //  has been delayed during activation
+    delayInitialFocusTimer: undefined,
   };
 
   let trap; // eslint-disable-line prefer-const -- some private functions reference it, and its methods reference private functions, so we must declare here and define later
@@ -439,7 +441,7 @@ const createFocusTrap = function (elements, userOptions) {
 
     // Delay ensures that the focused element doesn't capture the event
     // that caused the focus trap activation.
-    activeFocusDelay = config.delayInitialFocus
+    state.delayInitialFocusTimer = config.delayInitialFocus
       ? delay(function () {
           tryFocus(getInitialFocusNode());
         })
@@ -533,7 +535,8 @@ const createFocusTrap = function (elements, userOptions) {
         return this;
       }
 
-      clearTimeout(activeFocusDelay);
+      clearTimeout(state.delayInitialFocusTimer); // noop if undefined
+      state.delayInitialFocusTimer = undefined;
 
       removeListeners();
       state.active = false;


### PR DESCRIPTION
Fixes #441

Activating of the second trap, causing the first trap to pause and
remove listeners may sometimes thwart delayed initial focus in second
trap.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Includes updated `/docs/demo-bundle.js` if source or docs code was changed.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
