### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
       CI: true
     strategy:
       matrix:
-        node: [14]
+        node: [18]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup environment
         id: setups
         run: |-
-          echo "::set-output name=yarn_cache::$(yarn cache dir)"
+          echo "::set-output name=yarn_cache_dir::$(yarn cache dir)"
 
       - name: Setup Node ${{ matrix.node }}
         uses: actions/setup-node@master
@@ -31,10 +31,13 @@ jobs:
           check-latest: true
 
       - name: Yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.setups.outputs.yarn_cache }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-node-${{ matrix.node }}
+          path: ${{ steps.setups.outputs.yarn_cache_dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install packages
         run: yarn --frozen-lockfile
@@ -66,7 +69,7 @@ jobs:
       CYPRESS_BROWSER: ${{ matrix.browser }} # yarn start:cypress needs this
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Test E2E
         # https://github.com/cypress-io/github-action


### PR DESCRIPTION
Update to Node 18 for testing (use latest since this library is browser-focused anyway; it's just for tooling), actions/checkout@v3, actions/cache@v3.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Includes updated docs demo bundle if source/docs code was changed (run `yarn demo-bundle` in your branch and include the `/docs/demo-bundle.js` file that gets generated in your PR).
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E (i.e. demos) test coverage added/updated.
  - ⚠️ Non-covered demos (look for `IS_CYPRESS_ENV === ''` [here](https://github.com/focus-trap/focus-trap/blob/master/docs/js/index.js), as well as `in-open-shadow-dom.js` and `negative-tabindex.js` that can't be fully tested in Cypress) __manually__ verified.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
