### PR TITLE
expose activeFocusTraps

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Returns a new focus trap on `element` (one or more "containers" of tabbable node
 - **preventScroll** `{boolean}`: By default, focus() will scroll to the element if not in viewport. It can produce unintended effects like scrolling back to the top of a modal. If set to `true`, no scroll will happen.
 - **delayInitialFocus** `{boolean}`: Default: `true`. Delays the autofocus to the next execution frame when the focus trap is activated. This prevents elements within the focusable element from capturing the event that triggered the focus trap activation.
 - **document** {Document}: Default: `window.document`. Document where the focus trap will be active. This allows to use FocusTrap in an iFrame context.
-- **activeFocusTraps**: (optional) `{ activateTrap(trap: FocusTrap) => void, deactivateTrap(trap: FocusTrap) => void }` Enables to manualy handle multiple focus-trap instances.
+- **activeFocusTraps**: (optional) `{ activateTrap(trap: FocusTrap) => void, deactivateTrap(trap: FocusTrap) => void }` Enables to manually handle multiple focus-trap instances.
 - **tabbableOptions**: (optional) [tabbable options](https://github.com/focus-trap/tabbable#common-options) configurable on FocusTrap (all the *common options*).
   - ⚠️ See notes about **[testing in JSDom](#testing-in-jsdom)** (e.g. using Jest).
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Returns a new focus trap on `element` (one or more "containers" of tabbable node
 - **preventScroll** `{boolean}`: By default, focus() will scroll to the element if not in viewport. It can produce unintended effects like scrolling back to the top of a modal. If set to `true`, no scroll will happen.
 - **delayInitialFocus** `{boolean}`: Default: `true`. Delays the autofocus to the next execution frame when the focus trap is activated. This prevents elements within the focusable element from capturing the event that triggered the focus trap activation.
 - **document** {Document}: Default: `window.document`. Document where the focus trap will be active. This allows to use FocusTrap in an iFrame context.
+- **activeFocusTraps**: (optional) `{ activateTrap(trap: FocusTrap) => void, deactivateTrap(trap: FocusTrap) => void }` Enables to manualy handle multiple focus-trap instances.
 - **tabbableOptions**: (optional) [tabbable options](https://github.com/focus-trap/tabbable#common-options) configurable on FocusTrap (all the *common options*).
   - ⚠️ See notes about **[testing in JSDom](#testing-in-jsdom)** (e.g. using Jest).
 

--- a/cypress/e2e/focus-trap-demo.cy.js
+++ b/cypress/e2e/focus-trap-demo.cy.js
@@ -1531,6 +1531,58 @@ describe('focus-trap', () => {
     });
   });
 
+  describe('demo: custom focus-traps', () => {
+    it('traps focus tab sequence and allows deactivation by clicking deactivate button', () => {
+      cy.get('#demo-with-custom-active-focus-traps').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^activate trap/ })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
+      cy.get('#return-to-repo').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside un-focusable element)
+      cy.get('#demo-with-custom-active-focus-traps-heading').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap')
+        .tab()
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab()
+        .as('lastElementInTrap')
+        .should('contain', 'deactivate trap')
+        .should('be.focused')
+        .tab();
+
+      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
+      cy.get('@lastElementInTrap').should('be.focused');
+
+      // focus can be transitioned freely when trap is deactivated
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^deactivate trap/ })
+        .click();
+      verifyFocusIsNotTrapped(
+        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+      );
+    });
+  });
+
   // describe('demo: with-shadow-dom', () => {
   //   NOTE: Unfortunately, the https://github.com/Bkucera/cypress-plugin-tab plugin doesn't
   //    support Shadow DOM, and Cypress itself doesn't have great support for it either

--- a/docs/index.html
+++ b/docs/index.html
@@ -1022,6 +1022,30 @@
       </p>
     </div>
 
+    <div id="demo-with-custom-active-focus-traps">
+      <h2 id="demo-with-custom-active-focus-traps-heading">With custom activeFocusTraps</h2>
+
+      <p>
+        <button id="custom-active-focus-traps-activate" aria-describedby="demo-with-custom-active-focus-traps-heading">
+          activate trap
+        </button>
+      </p>
+      <div id="custom-active-focus-traps" class="trap">
+        <p>
+          Here is a focus trap <a href="#">with</a> <a href="#">some</a> <a href="#">focusable</a> parts.
+        </p>
+        <p>
+          <button id="custom-active-focus-traps-deactivate" aria-describedby="demo-with-custom-active-focus-traps-heading">
+            deactivate trap
+          </button>
+        </p>
+      </div>
+      <p>
+        <a href="https://github.com/focus-trap/focus-trap/blob/master/docs/js/custom-active-focus-traps.js">View demo source <span aria-hidden="true">&gt;&gt;</span></a>
+      </p>
+
+    </div>
+
     <p>
       <span aria-hidden="true" style="font-size:2em;vertical-align:middle;">☜</span>
       <a href="https://github.com/focus-trap/focus-trap" style="vertical-align:middle;">Return to the repository</a>

--- a/docs/js/custom-active-focus-traps.js
+++ b/docs/js/custom-active-focus-traps.js
@@ -1,0 +1,25 @@
+const { createFocusTrap } = require('../../index');
+
+module.exports = () => {
+  const container = document.getElementById('custom-active-focus-traps');
+
+  const activeFocusTraps = {
+    activateTrap: (trap) => {
+      container.classList.add('is-active');
+    },
+    deactivateTrap: (trap) => {
+      container.classList.remove('is-active');
+    },
+  };
+
+  const focusTrap = createFocusTrap(container, {
+    activeFocusTraps,
+  });
+
+  document
+    .getElementById('custom-active-focus-traps-activate')
+    .addEventListener('click', focusTrap.activate);
+  document
+    .getElementById('custom-active-focus-traps-deactivate')
+    .addEventListener('click', focusTrap.deactivate);
+};

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -1,4 +1,5 @@
 require('./default')();
+require('./custom-active-focus-traps')();
 require('./animated-dialog')();
 require('./animated-trigger')();
 require('./escape-deactivates')();

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,11 @@ declare module 'focus-trap' {
   type MouseEventToBoolean = (event: MouseEvent | TouchEvent) => boolean;
   type KeyboardEventToBoolean = (event: KeyboardEvent) => boolean;
 
+  interface ActiveFocusTraps {
+    activateTrap(trap: FocusTrap): void;
+    deactivateTrap(trap: FocusTrap): void;
+  }
+
   /** tabbable options supported by focus-trap. */
   export interface FocusTrapTabbableOptions extends TabbableCheckOptions {
   }
@@ -36,7 +41,7 @@ declare module 'focus-trap' {
      * A function that will be called **after** focus has been sent to the
      * target element upon activation.
      */
-    onPostActivate?: () => void
+    onPostActivate?: () => void;
 
     /**
      * A function for determining if it is safe to send focus to the focus trap
@@ -49,7 +54,9 @@ declare module 'focus-trap' {
      * dialogs that fade in and out. When a dialog fades in, there is a brief delay
      * between the activation of the trap and the trap element being focusable.
      */
-    checkCanFocusTrap?: (containers: Array<HTMLElement | SVGElement>) => Promise<void>
+    checkCanFocusTrap?: (
+      containers: Array<HTMLElement | SVGElement>
+    ) => Promise<void>;
 
     /**
      * A function that will be called **before** sending focus to the
@@ -62,7 +69,7 @@ declare module 'focus-trap' {
      * If `returnFocus` was set, it will be called **after** focus has been sent to the trigger
      * element upon deactivation; otherwise, it will be called after deactivation completes.
      */
-    onPostDeactivate?: () => void
+    onPostDeactivate?: () => void;
     /**
      * A function for determining if it is safe to send focus back to the `trigger` element.
      *
@@ -78,7 +85,7 @@ declare module 'focus-trap' {
      * This handler is **not** called if the `returnFocusOnDeactivate` configuration option
      * (or the `returnFocus` deactivation option) is falsy.
      */
-    checkCanReturnFocus?: (trigger: HTMLElement | SVGElement) => Promise<void>
+    checkCanReturnFocus?: (trigger: HTMLElement | SVGElement) => Promise<void>;
 
     /**
      * By default, when a focus trap is activated the first element in the
@@ -115,7 +122,11 @@ declare module 'focus-trap' {
      * By default, focus trap on deactivation will return to the element
      * that was focused before activation.
      */
-    setReturnFocus?: FocusTargetValueOrFalse | ((nodeFocusedBeforeActivation: HTMLElement | SVGElement) => FocusTargetValueOrFalse);
+    setReturnFocus?:
+      | FocusTargetValueOrFalse
+      | ((
+          nodeFocusedBeforeActivation: HTMLElement | SVGElement
+        ) => FocusTargetValueOrFalse);
     /**
      * Default: `true`. If `false` or returns `false`, the `Escape` key will not trigger
      * deactivation of the focus trap. This can be useful if you want
@@ -163,6 +174,11 @@ declare module 'focus-trap' {
      * Specific tabbable options configurable on focus-trap.
      */
     tabbableOptions?: FocusTrapTabbableOptions;
+
+    /**
+     * Define custom activeFocusTraps
+     */
+    activeFocusTraps?: ActiveFocusTraps;
   }
 
   type ActivateOptions = Pick<Options, 'onActivate' | 'onPostActivate' | 'checkCanFocusTrap'>;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { tabbable, focusable, isFocusable, isTabbable } from 'tabbable';
 
-const activeFocusTraps = (function () {
+const rootActiveFocusTraps = (function () {
   const trapQueue = [];
   return {
     activateTrap(trap) {
@@ -99,6 +99,9 @@ const createFocusTrap = function (elements, userOptions) {
   // SSR: a live trap shouldn't be created in this type of environment so this
   //  should be safe code to execute if the `document` option isn't specified
   const doc = userOptions?.document || document;
+
+  const activeFocusTraps =
+    userOptions?.activeFocusTraps || rootActiveFocusTraps;
 
   const config = {
     returnFocusOnDeactivate: true,


### PR DESCRIPTION
Expose `activeFocusTraps` to make able to deal with multiple versions of `focus-trap` in the same page.

```js
window.__trapQueue = window.__trapQueue ?? []

const activeFocusTraps = (function () {
  const trapQueue = window.__trapQueue;

  return {
    activateTrap(trap) {
      // --
    },

    deactivateTrap(trap) {
      // --
    },
  };
})();

const focusTrap = createFocusTrap(container, {
  activeFocusTraps,
});
```