### PR TITLE
Update contributor documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you added/removed options in the API, please remember to update the docs in t
 
 ## Changeset
 
-Before posting your PR, please add a changeset by running `npm run changeset` and following the prompts. This will help us quickly make a release with your enhancements.
+Before posting your PR, please add a changeset by running `npx changeset` and following the prompts. This will help us quickly make a release with your enhancements.
 
 If your changes don't affect the source or typings, then a changeset is not needed (and you can ignore the bot's automated comment on your PR about not finding one as part of your changes).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Then open your browser to http://localhost:9966
 
 ## Testing
 
-When you're done with your changes, be sure to run `npm run format` to have Prettier format your code, and use `npm run lint` to check for syntax issues. `npm run test:cypress` will run e2e tests in interactive mode.
+When you're done with your changes, be sure to run `npm run format` to have Prettier format your code, and use `npm run lint` to check for syntax issues. `npm run test:e2e:dev` will run e2e tests in interactive mode.
 
 You can also simply run `npm test` to check all of the above.
 


### PR DESCRIPTION
While working on another issue I stumbled on a few inconsistencies in `CONTRIBUTING.md`. This involves working with Cypress tests and changesets. This PR tries to fix these.

### Cypress tests

There is no longer a script name called `test:cypress`. The correct script name for running Cypress tests in interactive mode is `test:e2e:dev`.

### Changesets

The documentation currently refers to running `npm run changeset` but there is no `changeset` script in `package.json`.

Using `npx` to run the executable from `changeset/cli` seems to be the best bet.

One alternative approach would be to add a `changeset` script to execute `changeset/cli`.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Includes updated docs demo bundle if source/docs code was changed (run `npm run demo-bundle` in your branch and include the `/docs/demo-bundle.js` file that gets generated in your PR).
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E (i.e. demos) test coverage added/updated.
  - ⚠️ Non-covered demos (look for `// TEST MANUALLY` comments [here](https://github.com/focus-trap/focus-trap/blob/master/docs/js/index.js)) that can't be fully tested in Cypress have been __manually__ verified.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
