### PR TITLE
fix(typings): Updates typings for the document option to support shadow DOM host elements

### DIFF
--- a/.changeset/soft-actors-cheat.md
+++ b/.changeset/soft-actors-cheat.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Updates typings for the document option to support shadow DOM host elements

--- a/index.d.ts
+++ b/index.d.ts
@@ -185,9 +185,9 @@ declare module 'focus-trap' {
     delayInitialFocus?: boolean;
     /**
      * Default: `window.document`. Document where the focus trap will be active.
-     * This allows to use FocusTrap in an iFrame context.
+     * This allows to use FocusTrap in an iFrame context or to configure the focus trap to use your shadow host element as its document.
      */
-    document?: Document;
+    document?: Document | HTMLElement;
 
     /**
      * Specific tabbable options configurable on focus-trap.


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

Modifies the typescript typings file to add to the document option so that a typescript user can set any HTML element as the document. This will allow the document to be set to shadow DOM elements.

Fixes #939

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Includes updated docs demo bundle if source/docs code was changed (run `npm run demo-bundle` in your branch and include the `/docs/demo-bundle.js` file that gets generated in your PR).
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E (i.e. demos) test coverage added/updated.
  - ⚠️ Non-covered demos (look for `// TEST MANUALLY` comments [here](https://github.com/focus-trap/focus-trap/blob/master/docs/js/index.js)) that can't be fully tested in Cypress have been __manually__ verified.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
