### PR TITLE
Remove references to `Array.prototype.findLast()`

### DIFF
--- a/.changeset/afraid-carrots-lick.md
+++ b/.changeset/afraid-carrots-lick.md
@@ -1,0 +1,5 @@
+---
+"focus-trap": patch
+---
+
+Remove references to `Array.prototype.findLast()` not well supported in Safari ([#996](https://github.com/focus-trap/focus-trap/issues/996))

--- a/index.js
+++ b/index.js
@@ -316,9 +316,10 @@ const createFocusTrap = function (elements, userOptions) {
       const firstDomTabbableNode = focusableNodes.find((node) =>
         isTabbable(node)
       );
-      const lastDomTabbableNode = focusableNodes.findLast((node) =>
-        isTabbable(node)
-      );
+      const lastDomTabbableNode = focusableNodes
+        .slice()
+        .reverse()
+        .find((node) => isTabbable(node));
 
       const posTabIndexesFound = !!tabbableNodes.find(
         (node) => getTabIndex(node) > 0
@@ -374,7 +375,8 @@ const createFocusTrap = function (elements, userOptions) {
 
             return focusableNodes
               .slice(0, focusableNodes.indexOf(node))
-              .findLast((el) => isTabbable(el));
+              .reverse()
+              .find((el) => isTabbable(el));
           }
 
           return tabbableNodes[nodeIdx + (forward ? 1 : -1)];


### PR DESCRIPTION
This PR removes all the references to `Array.prototype.findLast()` in the codebase, because it doesn't have acceptable [browser support](https://caniuse.com/mdn-javascript_builtins_array_findlast).

Fixes https://github.com/focus-trap/focus-trap/issues/996.

<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->


<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Includes updated docs demo bundle if source/docs code was changed (run `npm run demo-bundle` in your branch and include the `/docs/demo-bundle.js` file that gets generated in your PR).
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E (i.e. demos) test coverage added/updated.
  - ⚠️ Non-covered demos (look for `// TEST MANUALLY` comments [here](https://github.com/focus-trap/focus-trap/blob/master/docs/js/index.js)) that can't be fully tested in Cypress have been __manually__ verified.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
