### PR TITLE
Remove recently-added engine requirement

### DIFF
--- a/.changeset/thirty-baboons-push.md
+++ b/.changeset/thirty-baboons-push.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Remove engine requirement that crept into `package.json`. Sorry about that! ([#1343](https://github.com/focus-trap/focus-trap/issues/1343))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,8 @@
 
 /* eslint-env node */
 
+import url from 'node:url';
+import path from 'node:path';
 import js from '@eslint/js';
 import globals from 'globals';
 import babel from '@babel/eslint-plugin';
@@ -17,9 +19,11 @@ import cypress from 'eslint-plugin-cypress';
 import importPlugin from 'eslint-plugin-import';
 import testingLibrary from 'eslint-plugin-testing-library';
 
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
 const ecmaVersion = 'latest';
 const impliedStrict = true;
-const tsconfigRootDir = import.meta.dirname;
+const tsconfigRootDir = __dirname;
 
 //
 // Plugins

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "focus-trap",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "focus-trap",
-      "version": "7.6.2",
+      "version": "7.6.3",
       "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
@@ -50,9 +50,6 @@
         "rollup-plugin-serve": "^3.0.0",
         "start-server-and-test": "^2.0.9",
         "typescript": "^5.7.2"
-      },
-      "engines": {
-        "node": "^20.11.0 || >=21.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "focus-trap",
   "version": "7.6.3",
   "description": "Trap focus within a DOM node.",
-  "engines": {
-    "node": "^20.11.0 || >=21.2.0"
-  },
   "main": "dist/focus-trap.js",
   "module": "dist/focus-trap.esm.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Fixes #1343

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain stated browser compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Includes updated docs demo bundle if source/docs code was changed (run `npm run demo-bundle` in your branch and include the `/docs/demo-bundle.js` file that gets generated in your PR).
- Unit test coverage added/updated.
- E2E (i.e. demos) test coverage added/updated.
  - ⚠️ Non-covered demos (look for `// TEST MANUALLY` comments [here](https://github.com/focus-trap/focus-trap/blob/master/docs/js/index.js)) that can't be fully tested in Cypress have been __manually__ verified.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
