### PR TITLE
Update release workflow for NPM Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [master]
 
+permissions:
+  # `id-token` and `contents` are requried for NPM Trusted Publishing with OIDC
+  # @see https://docs.npmjs.com/trusted-publishers
+  id-token: write
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -11,7 +17,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -21,27 +27,17 @@ jobs:
           echo "npm-cache-dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           check-latest: true
+          registry-url: 'https://registry.npmjs.org' # required for NPM Trusted Publishing
 
-      # TODO: this does work (it'll find the cache) but it appears it's not putting the cache
-      #  back into ./node_modules because skipping the install step results in subsequent
-      #  steps failing with messages like `prettier not found`, which implies there's no
-      #  node_modules directory there with Prettier installed in it...
-      #
-      # - name: NPM cache check
-      #   uses: actions/cache@v3
-      #   id: npm-cache
-      #   with:
-      #     path: ${{ steps.setup.outputs.npm-cache-dir }}
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-node-
+      # Ensure npm >=11.5.1 installed for NPM Trusted Publishing
+      - name: Updated npm
+        run: npm install -g npm@latest
 
       - name: Install packages
-        # if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Test All
@@ -54,4 +50,3 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Updated the release workflow to use newer versions of actions and Node.js, added permissions for NPM Trusted Publishing, and removed unused cache steps.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain stated browser compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Includes updated docs demo bundle if source/docs code was changed (run `npm run demo-bundle` in your branch and include the `/docs/demo-bundle.js` file that gets generated in your PR).
- Unit test coverage added/updated.
- E2E (i.e. demos) test coverage added/updated.
  - ⚠️ Non-covered demos (look for `// TEST MANUALLY` comments [here](https://github.com/focus-trap/focus-trap/blob/master/docs/js/index.js)) that can't be fully tested in Cypress have been __manually__ verified.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure with enhanced security configurations and dependency upgrades to ensure more reliable and secure releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->