### PR TITLE
feat: pass focus trap as lifecycle hook parameter

### DIFF
--- a/.changeset/rude-crabs-hope.md
+++ b/.changeset/rude-crabs-hope.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': minor
+---
+
+Update lifecycle hooks to include the associated focus trap as a parameter.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Returns a new focus trap on `element` (one or more "containers" of tabbable node
 ##### onActivate
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called **before** sending focus to the target element upon activation.
@@ -102,7 +102,7 @@ A function that will be called **before** sending focus to the target element up
 ##### onPostActivate
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called **after** sending focus to the target element upon activation **unless** initial focus is delayed because the  [delayInitialFocus](#delayinitialfocus) is true (default).
@@ -110,7 +110,7 @@ A function that will be called **after** sending focus to the target element upo
 ##### onPause
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called immediately after the trap's state is updated to be paused.
@@ -118,7 +118,7 @@ A function that will be called immediately after the trap's state is updated to 
 ##### onPostPause
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called after the trap has been completely paused and is no longer managing/trapping focus.
@@ -126,7 +126,7 @@ A function that will be called after the trap has been completely paused and is 
 ##### onUnpause
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called immediately after the trap's state is updated to be active again, but prior to updating its knowledge of what nodes are tabbable within its containers, and prior to actively managing/trapping focus.
@@ -134,7 +134,7 @@ A function that will be called immediately after the trap's state is updated to 
 ##### onPostUnpause
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called after the trap has been completely unpaused and is once again managing/trapping focus.
@@ -154,7 +154,7 @@ Animated dialogs have a small delay between when `onActivate` is called and when
 ##### onDeactivate
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called **before** returning focus to the node that had focus prior to activation (or configured with the `setReturnFocus` option) upon deactivation.
@@ -162,7 +162,7 @@ A function that will be called **before** returning focus to the node that had f
 ##### onPostDeactivate
 
 ```typescript
-() => void
+({ trap: FocusTrap }) => void
 ```
 
 A function that will be called after the trap is deactivated, after `onDeactivate`. If the `returnFocus` deactivation option was set, it will be called **after** returning focus to the node that had focus prior to activation (or configured with the `setReturnFocus` option) upon deactivation; otherwise, it will be called after deactivation completes.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Returns a new focus trap on `element` (one or more "containers" of tabbable node
 ##### onActivate
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called **before** sending focus to the target element upon activation.
@@ -102,7 +102,7 @@ A function that will be called **before** sending focus to the target element up
 ##### onPostActivate
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called **after** sending focus to the target element upon activation **unless** initial focus is delayed because the  [delayInitialFocus](#delayinitialfocus) is true (default).
@@ -110,7 +110,7 @@ A function that will be called **after** sending focus to the target element upo
 ##### onPause
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called immediately after the trap's state is updated to be paused.
@@ -118,7 +118,7 @@ A function that will be called immediately after the trap's state is updated to 
 ##### onPostPause
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called after the trap has been completely paused and is no longer managing/trapping focus.
@@ -126,7 +126,7 @@ A function that will be called after the trap has been completely paused and is 
 ##### onUnpause
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called immediately after the trap's state is updated to be active again, but prior to updating its knowledge of what nodes are tabbable within its containers, and prior to actively managing/trapping focus.
@@ -134,7 +134,7 @@ A function that will be called immediately after the trap's state is updated to 
 ##### onPostUnpause
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called after the trap has been completely unpaused and is once again managing/trapping focus.
@@ -154,7 +154,7 @@ Animated dialogs have a small delay between when `onActivate` is called and when
 ##### onDeactivate
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called **before** returning focus to the node that had focus prior to activation (or configured with the `setReturnFocus` option) upon deactivation.
@@ -162,7 +162,7 @@ A function that will be called **before** returning focus to the node that had f
 ##### onPostDeactivate
 
 ```typescript
-({ trap: FocusTrap }) => void
+(params: LifecycleParameters) => void
 ```
 
 A function that will be called after the trap is deactivated, after `onDeactivate`. If the `returnFocus` deactivation option was set, it will be called **after** returning focus to the node that had focus prior to activation (or configured with the `setReturnFocus` option) upon deactivation; otherwise, it will be called after deactivation completes.
@@ -389,8 +389,8 @@ Returns the `trap`.
 
 These options are used to override the focus trap's default behavior for this particular activation.
 
-- **onActivate** `{() => void}`: Default: whatever you chose for `createOptions.onActivate`. `null` or `false` are the equivalent of a `noop`.
-- **onPostActivate** `{() => void}`: Default: whatever you chose for `createOptions.onPostActivate`. `null` or `false` are the equivalent of a `noop`.
+- **onActivate** `{(params: LifecycleParameters) => void}`: Default: whatever you chose for `createOptions.onActivate`. `null` or `false` are the equivalent of a `noop`.
+- **onPostActivate** `{(params: LifecycleParameters) => void}`: Default: whatever you chose for `createOptions.onPostActivate`. `null` or `false` are the equivalent of a `noop`.
 - **checkCanFocusTrap** `{(containers: Array<HTMLElement | SVGElement>) => Promise<unknown>}`: Default: whatever you chose for `createOptions.checkCanFocusTrap`.
 
 ### trap.deactivate()
@@ -408,8 +408,8 @@ Returns the `trap`.
 These options are used to override the focus trap's default behavior for this particular deactivation.
 
 - **returnFocus** `{boolean}`: Default: whatever you set for `createOptions.returnFocusOnDeactivate`. If `true`, then the `setReturnFocus` option (specified when the trap was created) is used to determine where focus will be returned.
-- **onDeactivate** `{() => void}`: Default: whatever you set for `createOptions.onDeactivate`. `null` or `false` are the equivalent of a `noop`.
-- **onPostDeactivate** `{() => void}`: Default: whatever you set for `createOptions.onPostDeactivate`. `null` or `false` are the equivalent of a `noop`.
+- **onDeactivate** `{(params: LifecycleParameters) => void}`: Default: whatever you set for `createOptions.onDeactivate`. `null` or `false` are the equivalent of a `noop`.
+- **onPostDeactivate** `{(params: LifecycleParameters) => void}`: Default: whatever you set for `createOptions.onPostDeactivate`. `null` or `false` are the equivalent of a `noop`.
 - **checkCanReturnFocus** `{(trigger: HTMLElement | SVGElement) => Promise<void>}`: Default: whatever you set for `createOptions.checkCanReturnFocus`. Not called if the `returnFocus` option is falsy. `trigger` is either the originally focused node prior to activation, or the result of the `setReturnFocus` configuration option.
 
 ### trap.pause()
@@ -436,8 +436,8 @@ This is useful in various cases, one of which is when you want one focus trap wi
 
 These options are used to override the focus trap's default behavior for this particular pausing.
 
-- **onPause** `{() => void}`: Default: whatever you chose for `createOptions.onPause`. `null` or `false` are the equivalent of a `noop`.
-- **onPostPause** `{() => void}`: Default: whatever you chose for `createOptions.onPostPause`. `null` or `false` are the equivalent of a `noop`.
+- **onPause** `{(params: LifecycleParameters) => void}`: Default: whatever you chose for `createOptions.onPause`. `null` or `false` are the equivalent of a `noop`.
+- **onPostPause** `{(params: LifecycleParameters) => void}`: Default: whatever you chose for `createOptions.onPostPause`. `null` or `false` are the equivalent of a `noop`.
 
 ### trap.unpause()
 
@@ -461,8 +461,8 @@ Returns the `trap`.
 
 These options are used to override the focus trap's default behavior for this particular unpausing.
 
-- **onUnpause** `{() => void}`: Default: whatever you chose for `createOptions.onUnpause`. `null` or `false` are the equivalent of a `noop`.
-- **onPostUnpause** `{() => void}`: Default: whatever you chose for `createOptions.onPostUnpause`. `null` or `false` are the equivalent of a `noop`.
+- **onUnpause** `{(params: LifecycleParameters) => void}`: Default: whatever you chose for `createOptions.onUnpause`. `null` or `false` are the equivalent of a `noop`.
+- **onPostUnpause** `{(params: LifecycleParameters) => void}`: Default: whatever you chose for `createOptions.onPostUnpause`. `null` or `false` are the equivalent of a `noop`.
 
 ### trap.updateContainerElements()
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,10 +27,10 @@ declare module 'focus-trap' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Reserving ability to add/remove properties in the future
   export interface FocusTrapTabbableOptions extends TabbableCheckOptions {}
 
-/**
- * Standard non-positional parameters for lifecycle hooks in {@link Options}.
- */
-export type LifecycleParameters = {
+  /**
+   * Standard non-positional parameters for lifecycle hooks in {@link Options}.
+   */
+  export type LifecycleParameters = {
     /**
      * The focus trap associated with the lifecycle hook.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,10 @@ declare module 'focus-trap' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Reserving ability to add/remove properties in the future
   export interface FocusTrapTabbableOptions extends TabbableCheckOptions {}
 
-  type LifecycleParameters = {
+  export type LifecycleParameters = {
+    /**
+     * The focus trap associated with the lifecycle hook.
+     */
     trap: FocusTrap;
   };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,42 +27,46 @@ declare module 'focus-trap' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Reserving ability to add/remove properties in the future
   export interface FocusTrapTabbableOptions extends TabbableCheckOptions {}
 
+  type LifecycleParameters = {
+    trap: FocusTrap;
+  };
+
   export interface Options {
     /**
      * A function that will be called **before** sending focus to the
      * target element upon activation.
      */
-    onActivate?: () => void;
+    onActivate?: (params: LifecycleParameters) => void;
 
     /**
      * A function that will be called **after** focus has been sent to the
      * target element upon activation.
      */
-    onPostActivate?: () => void;
+    onPostActivate?: (params: LifecycleParameters) => void;
 
     /**
      * A function that will be called immediately after the trap's state is updated to be paused.
      */
-    onPause?: () => void;
+    onPause?: (params: LifecycleParameters) => void;
 
     /**
      * A function that will be called after the trap has been completely paused and is no longer
      *  managing/trapping focus.
      */
-    onPostPause?: () => void;
+    onPostPause?: (params: LifecycleParameters) => void;
 
     /**
      * A function that will be called immediately after the trap's state is updated to be active
      *  again, but prior to updating its knowledge of what nodes are tabbable within its containers,
      *  and prior to actively managing/trapping focus.
      */
-    onUnpause?: () => void;
+    onUnpause?: (params: LifecycleParameters) => void;
 
     /**
      * A function that will be called after the trap has been completely unpaused and is once
      *  again managing/trapping focus.
      */
-    onPostUnpause?: () => void;
+    onPostUnpause?: (params: LifecycleParameters) => void;
 
     /**
      * A function for determining if it is safe to send focus to the focus trap
@@ -86,14 +90,14 @@ declare module 'focus-trap' {
      * A function that will be called **before** sending focus to the
      * trigger element upon deactivation.
      */
-    onDeactivate?: () => void;
+    onDeactivate?: (params: LifecycleParameters) => void;
 
     /**
      * A function that will be called after the trap is deactivated, after `onDeactivate`.
      * If `returnFocus` was set, it will be called **after** focus has been sent to the trigger
      * element upon deactivation; otherwise, it will be called after deactivation completes.
      */
-    onPostDeactivate?: () => void;
+    onPostDeactivate?: (params: LifecycleParameters) => void;
     /**
      * A function for determining if it is safe to send focus back to the `trigger` element.
      *

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,10 @@ declare module 'focus-trap' {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Reserving ability to add/remove properties in the future
   export interface FocusTrapTabbableOptions extends TabbableCheckOptions {}
 
-  export type LifecycleParameters = {
+/**
+ * Standard non-positional parameters for lifecycle hooks in {@link Options}.
+ */
+export type LifecycleParameters = {
     /**
      * The focus trap associated with the lifecycle hook.
      */

--- a/index.js
+++ b/index.js
@@ -1059,7 +1059,7 @@ const createFocusTrap = function (elements, userOptions) {
         state.paused = false;
         state.nodeFocusedBeforeActivation = getActiveElement(doc);
 
-        onActivate?.();
+        onActivate?.({ trap });
 
         const finishActivation = async () => {
           if (checkCanFocusTrap) {
@@ -1075,7 +1075,7 @@ const createFocusTrap = function (elements, userOptions) {
 
           trap._setSubtreeIsolation(true);
           updateObservedNodes();
-          onPostActivate?.();
+          onPostActivate?.({ trap });
         };
 
         if (checkCanFocusTrap) {
@@ -1143,14 +1143,14 @@ const createFocusTrap = function (elements, userOptions) {
         'returnFocusOnDeactivate'
       );
 
-      onDeactivate?.();
+      onDeactivate?.({ trap });
 
       const finishDeactivation = () => {
         delay(() => {
           if (returnFocus) {
             tryFocus(getReturnFocusNode(state.nodeFocusedBeforeActivation));
           }
-          onPostDeactivate?.();
+          onPostDeactivate?.({ trap });
         });
       };
 
@@ -1231,18 +1231,18 @@ const createFocusTrap = function (elements, userOptions) {
         if (paused) {
           const onPause = getOption(options, 'onPause');
           const onPostPause = getOption(options, 'onPostPause');
-          onPause?.();
+          onPause?.({ trap });
 
           removeListeners();
           trap._setSubtreeIsolation(false);
           updateObservedNodes();
 
-          onPostPause?.();
+          onPostPause?.({ trap });
         } else {
           const onUnpause = getOption(options, 'onUnpause');
           const onPostUnpause = getOption(options, 'onPostUnpause');
 
-          onUnpause?.();
+          onUnpause?.({ trap });
 
           const finishUnpause = async () => {
             updateTabbableNodes();
@@ -1256,7 +1256,7 @@ const createFocusTrap = function (elements, userOptions) {
 
             trap._setSubtreeIsolation(true);
             updateObservedNodes();
-            onPostUnpause?.();
+            onPostUnpause?.({ trap });
           };
 
           finishUnpause();

--- a/test/suites/basic.test.js
+++ b/test/suites/basic.test.js
@@ -1,5 +1,4 @@
 import { waitFor } from '@testing-library/dom';
-import userEvent from '@testing-library/user-event';
 
 import { createFocusTrap } from '../../index';
 
@@ -14,25 +13,110 @@ describe('basic', () => {
     };
   });
 
-  it('should activate and deactivate', async () => {
+  it('should run all lifecycle callbacks and pass the trap as an argument', async () => {
     /** @type {import('../tools/testingUtility.js').RenderResults} */
     const results = renderFixture('basic');
-    const { activateEl, deactivateEl, trapEl } = results;
+    const { activateEl, trapEl } = results;
 
-    const focusTrap = createFocusTrap(trapEl, {
+    const lifecycleEvents = [];
+
+    // eslint-disable-next-line prefer-const -- disabling as ignoreReadBeforeAssign is set to false
+    let focusTrap;
+    const makeLifecycleCallback = (name, effect) =>
+      jest.fn(({ trap }) => {
+        lifecycleEvents.push(name);
+        expect(trap).toBe(focusTrap);
+        effect?.();
+      });
+
+    const onActivate = makeLifecycleCallback('onActivate', () =>
+      trapEl?.classList.add('is-active')
+    );
+    const onPostActivate = makeLifecycleCallback('onPostActivate');
+    const onPause = makeLifecycleCallback('onPause');
+    const onPostPause = makeLifecycleCallback('onPostPause');
+    const onUnpause = makeLifecycleCallback('onUnpause');
+    const onPostUnpause = makeLifecycleCallback('onPostUnpause');
+    const onDeactivate = makeLifecycleCallback('onDeactivate', () =>
+      trapEl?.classList.remove('is-active')
+    );
+    const onPostDeactivate = makeLifecycleCallback('onPostDeactivate');
+
+    focusTrap = createFocusTrap(trapEl, {
       ...trapOptions,
-      onActivate: () => trapEl?.classList.add('is-active'),
-      onDeactivate: () => trapEl?.classList.remove('is-active'),
+      delayInitialFocus: false,
+      onActivate,
+      onPostActivate,
+      onPause,
+      onPostPause,
+      onUnpause,
+      onPostUnpause,
+      onDeactivate,
+      onPostDeactivate,
     });
-    activateEl?.addEventListener('click', focusTrap.activate);
-    deactivateEl?.addEventListener('click', focusTrap.deactivate);
 
+    activateEl?.focus();
+    expect(activateEl).toHaveFocus();
     expect(trapEl).not.toHaveClass('is-active');
+    expect(focusTrap.active).toBe(false);
+    expect(focusTrap.paused).toBe(false);
 
-    userEvent.click(activateEl);
-    await waitFor(() => expect(trapEl).toHaveClass('is-active'));
+    focusTrap.activate();
+    await waitFor(() => {
+      expect(trapEl).toHaveClass('is-active');
+      expect(onActivate).toHaveBeenCalledTimes(1);
+      expect(onPostActivate).toHaveBeenCalledTimes(1);
+    });
 
-    userEvent.click(deactivateEl);
-    await waitFor(() => expect(trapEl).not.toHaveClass('is-active'));
+    expect(onActivate).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(onPostActivate).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(focusTrap.active).toBe(true);
+    expect(focusTrap.paused).toBe(false);
+
+    focusTrap.pause();
+    await waitFor(() => {
+      expect(onPause).toHaveBeenCalledTimes(1);
+      expect(onPostPause).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onPause).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(onPostPause).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(focusTrap.active).toBe(true);
+    expect(focusTrap.paused).toBe(true);
+
+    focusTrap.unpause();
+    await waitFor(() => {
+      expect(onUnpause).toHaveBeenCalledTimes(1);
+      expect(onPostUnpause).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onUnpause).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(onPostUnpause).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(focusTrap.active).toBe(true);
+    expect(focusTrap.paused).toBe(false);
+
+    focusTrap.deactivate();
+    await waitFor(() => {
+      expect(trapEl).not.toHaveClass('is-active');
+      expect(activateEl).toHaveFocus();
+      expect(onDeactivate).toHaveBeenCalledTimes(1);
+      expect(onPostDeactivate).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onDeactivate).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(onPostDeactivate).toHaveBeenCalledWith({ trap: focusTrap });
+    expect(focusTrap.active).toBe(false);
+    expect(focusTrap.paused).toBe(false);
+
+    expect(lifecycleEvents).toEqual([
+      'onActivate',
+      'onPostActivate',
+      'onPause',
+      'onPostPause',
+      'onUnpause',
+      'onPostUnpause',
+      'onDeactivate',
+      'onPostDeactivate',
+    ]);
   });
 });

--- a/test/suites/basic.test.js
+++ b/test/suites/basic.test.js
@@ -13,7 +13,7 @@ describe('basic', () => {
     };
   });
 
-  it('should run all lifecycle callbacks and pass the trap as an argument', async () => {
+  it('should run all lifecycle callbacks', async () => {
     /** @type {import('../tools/testingUtility.js').RenderResults} */
     const results = renderFixture('basic');
     const { activateEl, trapEl } = results;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This came up in https://github.com/focus-trap/focus-trap/issues/1846#issuecomment-4305492793 as an enhancement to support more advanced `focus-trap` configurations.

**Disclaimer**: test updates were generated by Copilot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lifecycle callbacks now receive the active focus-trap instance as a parameter.

* **Documentation**
  * Updated docs and type examples to reflect the new callback parameter.

* **Tests**
  * Expanded tests to verify lifecycle callbacks fire in order, receive the parameter, and that activation/pause state transitions behave as expected.

* **Chores**
  * Added a changeset to record a minor version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->