### PR TITLE
[#1689] Add delayReturnFocus timing option and tests

### DIFF
--- a/.changeset/three-clowns-swim.md
+++ b/.changeset/three-clowns-swim.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': minor
+---
+
+Add new `delayReturnFocus` option (default true) to control whether return focus and onPostDeactivate are deferred by one frame.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Note that if [delayInitialFocus](#delayinitialfocus) is true, this handler will 
 Animated dialogs have a small delay between when `onActivate` is called and when the focus trap is focusable. `checkCanFocusTrap` expects a promise to be returned. When that promise settles (resolves or rejects), focus will be sent to the first tabbable node (in tab order) in the focus trap (or the node configured in the `initialFocus` option).
 
 🔺 It does not matter whether the Promise resolves or rejects, only that it settles. A rejected Promise will not result in cancellation of trap activation.
+🔺 This controls **when activation may proceed**. The separate [delayInitialFocus](#delayinitialfocus) option controls whether there is an additional one-frame delay before focus is sent once activation can proceed.
 
 ##### onDeactivate
 
@@ -167,6 +168,8 @@ A function that will be called **before** returning focus to the node that had f
 
 A function that will be called after the trap is deactivated, after `onDeactivate`. If the `returnFocus` deactivation option was set, it will be called **after** returning focus to the node that had focus prior to activation (or configured with the `setReturnFocus` option) upon deactivation; otherwise, it will be called after deactivation completes.
 
+By default, this callback is delayed by one frame along with return-focus timing; set [delayReturnFocus](#delayreturnfocus) to `false` to remove that extra delay.
+
 ##### checkCanReturnFocus
 
 ```typescript
@@ -174,6 +177,8 @@ A function that will be called after the trap is deactivated, after `onDeactivat
 ```
 
 An animated trigger button will have a small delay between when `onDeactivate` is called and when the focus is able to be sent back to the trigger. `checkCanReturnFocus` expects a promise to be returned. When that promise settles (resolves or rejects), focus will be sent to to the node that had focus prior to the activation of the trap (or the node configured in the `setReturnFocus` option).
+
+🔺 If [delayReturnFocus](#delayreturnfocus) is `true` (default), there is still an additional one-frame delay after this Promise settles before focus is returned and `onPostDeactivate` is called.
 
 ##### initialFocus
 
@@ -272,6 +277,19 @@ boolean
 Default: `true`. Delays the autofocus to the next execution frame when the focus trap is activated. This prevents elements within the focusable element from capturing the event that triggered the focus trap activation.
 
 🔺 Note that when this option is `true` (default), it means the initial element to be focused will not be focused until **after** [onPostActivate](#onpostactivate) or [onPostUnpause](#onpostunpause) are called.
+🔺 This option controls the extra frame delay on activation. Use [checkCanFocusTrap](#checkcanfocustrap) to gate activation readiness, and [delayReturnFocus](#delayreturnfocus) plus [checkCanReturnFocus](#checkcanreturnfocus) for the equivalent deactivation timing controls.
+
+##### delayReturnFocus
+
+```typescript
+boolean
+```
+
+Default: `true`. Delays return-focus to the next execution frame when the focus trap is deactivated.
+
+- This same delay also applies to [onPostDeactivate](#onpostdeactivate).
+- Set to `false` to skip the extra frame delay.
+- If [checkCanReturnFocus](#checkcanreturnfocus) is configured, that Promise must still settle first.
 
 ##### isolateSubtrees
 
@@ -410,7 +428,7 @@ These options are used to override the focus trap's default behavior for this pa
 - **returnFocus** `{boolean}`: Default: whatever you set for `createOptions.returnFocusOnDeactivate`. If `true`, then the `setReturnFocus` option (specified when the trap was created) is used to determine where focus will be returned.
 - **onDeactivate** `{(params: LifecycleParameters) => void}`: Default: whatever you set for `createOptions.onDeactivate`. `null` or `false` are the equivalent of a `noop`.
 - **onPostDeactivate** `{(params: LifecycleParameters) => void}`: Default: whatever you set for `createOptions.onPostDeactivate`. `null` or `false` are the equivalent of a `noop`.
-- **checkCanReturnFocus** `{(trigger: HTMLElement | SVGElement) => Promise<void>}`: Default: whatever you set for `createOptions.checkCanReturnFocus`. Not called if the `returnFocus` option is falsy. `trigger` is either the originally focused node prior to activation, or the result of the `setReturnFocus` configuration option.
+- **checkCanReturnFocus** `{(trigger: HTMLElement | SVGElement) => Promise<void>}`: Default: whatever you set for `createOptions.checkCanReturnFocus`. Not called if the `returnFocus` option is falsy. `trigger` is either the originally focused node prior to activation, or the result of the `setReturnFocus` configuration option. After this Promise settles, `createOptions.delayReturnFocus` determines whether return-focus and `onPostDeactivate` are immediate (`false`) or delayed by one frame (`true`, default).
 
 ### trap.pause()
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,6 +102,8 @@ declare module 'focus-trap' {
      * A function that will be called after the trap is deactivated, after `onDeactivate`.
      * If `returnFocus` was set, it will be called **after** focus has been sent to the trigger
      * element upon deactivation; otherwise, it will be called after deactivation completes.
+     * The return-focus and this callback timing can be delayed by one frame via
+     * `delayReturnFocus` (default `true`).
      */
     onPostDeactivate?: (params: LifecycleParameters) => void;
     /**
@@ -118,6 +120,9 @@ declare module 'focus-trap' {
      *
      * This handler is **not** called if the `returnFocusOnDeactivate` configuration option
      * (or the `returnFocus` deactivation option) is falsy.
+     *
+     * 🔺 If `delayReturnFocus` is `true` (default), there is still a one-frame delay after
+     * this Promise settles before focus is returned and `onPostDeactivate` is called.
      */
     checkCanReturnFocus?: (trigger: HTMLElement | SVGElement) => Promise<void>;
 
@@ -199,8 +204,18 @@ declare module 'focus-trap' {
      * Default: `true`. Delays the autofocus when the focus trap is activated.
      * This prevents elements within the focusable element from capturing
      * the event that triggered the focus trap activation.
+     * Use this with `checkCanFocusTrap` to control activation timing.
      */
     delayInitialFocus?: boolean;
+    /**
+     * Default: `true`. Delays return focus when the focus trap is deactivated.
+     * This also delays `onPostDeactivate` by one frame.
+     * Set to `false` to skip that extra delay.
+     *
+     * Note that `checkCanReturnFocus`, if configured, still gates deactivation timing:
+     * deactivation waits for that Promise to settle before this option is applied.
+     */
+    delayReturnFocus?: boolean;
     /**
      * Default: `false`. Prevents screen readers from accessing content outside
      * the focus trap. Values of `true` or `'inert'` use the `inert` attribute,

--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ const createFocusTrap = function (elements, userOptions) {
     returnFocusOnDeactivate: true,
     escapeDeactivates: true,
     delayInitialFocus: true,
+    delayReturnFocus: true,
     isolateSubtrees: false,
     isKeyForward,
     isKeyBackward,
@@ -1137,6 +1138,7 @@ const createFocusTrap = function (elements, userOptions) {
       const onDeactivate = getOption(options, 'onDeactivate');
       const onPostDeactivate = getOption(options, 'onPostDeactivate');
       const checkCanReturnFocus = getOption(options, 'checkCanReturnFocus');
+      const delayReturnFocus = getOption(options, 'delayReturnFocus');
       const returnFocus = getOption(
         options,
         'returnFocus',
@@ -1144,14 +1146,19 @@ const createFocusTrap = function (elements, userOptions) {
       );
 
       onDeactivate?.({ trap });
+      const completeDeactivation = () => {
+        if (returnFocus) {
+          tryFocus(getReturnFocusNode(state.nodeFocusedBeforeActivation));
+        }
+        onPostDeactivate?.({ trap });
+      };
 
       const finishDeactivation = () => {
-        delay(() => {
-          if (returnFocus) {
-            tryFocus(getReturnFocusNode(state.nodeFocusedBeforeActivation));
-          }
-          onPostDeactivate?.({ trap });
-        });
+        if (delayReturnFocus) {
+          delay(completeDeactivation);
+        } else {
+          completeDeactivation();
+        }
       };
 
       if (returnFocus && checkCanReturnFocus) {

--- a/index.js
+++ b/index.js
@@ -1154,7 +1154,7 @@ const createFocusTrap = function (elements, userOptions) {
       };
 
       const finishDeactivation = () => {
-        if (delayReturnFocus) {
+        if (delayReturnFocus && returnFocus) {
           delay(completeDeactivation);
         } else {
           completeDeactivation();

--- a/test/suites/lifecycleTiming.test.js
+++ b/test/suites/lifecycleTiming.test.js
@@ -170,6 +170,31 @@ describe('lifecycle timing', () => {
     }
   });
 
+  it('should call onPostDeactivate synchronously when returnFocus is false with default delayReturnFocus', () => {
+    jest.useFakeTimers();
+    try {
+      const events = [];
+      const { triggerEl, trapEl } = renderTrap('single-no-return-focus');
+      const trap = createFocusTrap(trapEl, {
+        ...baseTrapOptions,
+        onDeactivate: () => events.push('onDeactivate'),
+        onPostDeactivate: () => events.push('onPostDeactivate'),
+      });
+
+      triggerEl.focus();
+      trap.activate();
+      trap.deactivate({ returnFocus: false });
+
+      expect(events).toEqual(['onDeactivate', 'onPostDeactivate']);
+
+      jest.runOnlyPendingTimers();
+
+      expect(events).toEqual(['onDeactivate', 'onPostDeactivate']);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should skip one-frame delay after checkCanReturnFocus settles when delayReturnFocus is false', async () => {
     const events = [];
     const { triggerEl, trapEl } = renderTrap('single-no-delay');

--- a/test/suites/lifecycleTiming.test.js
+++ b/test/suites/lifecycleTiming.test.js
@@ -1,0 +1,204 @@
+import { waitFor } from '@testing-library/dom';
+
+import { createFocusTrap } from '../../index';
+
+describe('lifecycle timing', () => {
+  const baseTrapOptions = {
+    tabbableOptions: { displayCheck: 'none' },
+    delayInitialFocus: false,
+  };
+
+  const renderTrap = (id) => {
+    const triggerEl = document.createElement('button');
+    triggerEl.id = `${id}-trigger`;
+    triggerEl.textContent = `${id}-trigger`;
+
+    const trapEl = document.createElement('div');
+    trapEl.id = `${id}-trap`;
+
+    const trapButtonEl = document.createElement('button');
+    trapButtonEl.id = `${id}-inside`;
+    trapButtonEl.textContent = `${id}-inside`;
+    trapEl.appendChild(trapButtonEl);
+
+    document.body.appendChild(triggerEl);
+    document.body.appendChild(trapEl);
+
+    return { triggerEl, trapEl };
+  };
+
+  const createLifecycleCallbacks = (events, prefix) => ({
+    onActivate: () => events.push(`${prefix}:onActivate`),
+    onPostActivate: () => events.push(`${prefix}:onPostActivate`),
+    onDeactivate: () => events.push(`${prefix}:onDeactivate`),
+    onPostDeactivate: () => events.push(`${prefix}:onPostDeactivate`),
+  });
+
+  it('should keep deactivation post-callbacks asynchronous by default across stacked traps', async () => {
+    const events = [];
+    const trapStack = [];
+    const first = renderTrap('first');
+    const second = renderTrap('second');
+
+    const firstTrap = createFocusTrap(first.trapEl, {
+      ...baseTrapOptions,
+      trapStack,
+      ...createLifecycleCallbacks(events, 'trap1'),
+    });
+    const secondTrap = createFocusTrap(second.trapEl, {
+      ...baseTrapOptions,
+      trapStack,
+      ...createLifecycleCallbacks(events, 'trap2'),
+    });
+
+    first.triggerEl.focus();
+    firstTrap.activate();
+    await waitFor(() => expect(events).toContain('trap1:onPostActivate'));
+
+    second.triggerEl.focus();
+    secondTrap.activate();
+    await waitFor(() => expect(events).toContain('trap2:onPostActivate'));
+
+    secondTrap.deactivate();
+    firstTrap.deactivate();
+
+    await waitFor(() =>
+      expect(
+        events.filter((eventName) => eventName.endsWith('onPostDeactivate'))
+          .length
+      ).toBe(2)
+    );
+
+    expect(events).toEqual([
+      'trap1:onActivate',
+      'trap1:onPostActivate',
+      'trap2:onActivate',
+      'trap2:onPostActivate',
+      'trap2:onDeactivate',
+      'trap1:onDeactivate',
+      'trap2:onPostDeactivate',
+      'trap1:onPostDeactivate',
+    ]);
+  });
+
+  it('should pair deactivation callbacks when delayReturnFocus is false', async () => {
+    const events = [];
+    const trapStack = [];
+    const first = renderTrap('first-no-delay');
+    const second = renderTrap('second-no-delay');
+
+    const firstTrap = createFocusTrap(first.trapEl, {
+      ...baseTrapOptions,
+      trapStack,
+      delayReturnFocus: false,
+      ...createLifecycleCallbacks(events, 'trap1'),
+    });
+    const secondTrap = createFocusTrap(second.trapEl, {
+      ...baseTrapOptions,
+      trapStack,
+      delayReturnFocus: false,
+      ...createLifecycleCallbacks(events, 'trap2'),
+    });
+
+    first.triggerEl.focus();
+    firstTrap.activate();
+    await waitFor(() => expect(events).toContain('trap1:onPostActivate'));
+
+    second.triggerEl.focus();
+    secondTrap.activate();
+    await waitFor(() => expect(events).toContain('trap2:onPostActivate'));
+
+    secondTrap.deactivate();
+    firstTrap.deactivate();
+
+    await waitFor(() =>
+      expect(
+        events.filter((eventName) => eventName.endsWith('onPostDeactivate'))
+          .length
+      ).toBe(2)
+    );
+
+    expect(events).toEqual([
+      'trap1:onActivate',
+      'trap1:onPostActivate',
+      'trap2:onActivate',
+      'trap2:onPostActivate',
+      'trap2:onDeactivate',
+      'trap2:onPostDeactivate',
+      'trap1:onDeactivate',
+      'trap1:onPostDeactivate',
+    ]);
+  });
+
+  it('should keep one-frame delay after checkCanReturnFocus settles by default', async () => {
+    jest.useFakeTimers();
+    try {
+      const events = [];
+      const { triggerEl, trapEl } = renderTrap('single-default-delay');
+      let resolveCanReturnFocus;
+      const checkCanReturnFocus = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveCanReturnFocus = resolve;
+          })
+      );
+
+      const trap = createFocusTrap(trapEl, {
+        ...baseTrapOptions,
+        checkCanReturnFocus,
+        onDeactivate: () => events.push('onDeactivate'),
+        onPostDeactivate: () => events.push('onPostDeactivate'),
+      });
+
+      triggerEl.focus();
+      trap.activate();
+      trap.deactivate();
+
+      expect(checkCanReturnFocus).toHaveBeenCalledTimes(1);
+      expect(events).toEqual(['onDeactivate']);
+
+      resolveCanReturnFocus();
+      await Promise.resolve();
+
+      expect(events).toEqual(['onDeactivate']);
+
+      jest.runOnlyPendingTimers();
+
+      expect(events).toEqual(['onDeactivate', 'onPostDeactivate']);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should skip one-frame delay after checkCanReturnFocus settles when delayReturnFocus is false', async () => {
+    const events = [];
+    const { triggerEl, trapEl } = renderTrap('single-no-delay');
+    let resolveCanReturnFocus;
+    const checkCanReturnFocus = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveCanReturnFocus = resolve;
+        })
+    );
+
+    const trap = createFocusTrap(trapEl, {
+      ...baseTrapOptions,
+      delayReturnFocus: false,
+      checkCanReturnFocus,
+      onDeactivate: () => events.push('onDeactivate'),
+      onPostDeactivate: () => events.push('onPostDeactivate'),
+    });
+
+    triggerEl.focus();
+    trap.activate();
+    trap.deactivate();
+
+    expect(checkCanReturnFocus).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['onDeactivate']);
+
+    resolveCanReturnFocus();
+    await Promise.resolve();
+
+    expect(events).toEqual(['onDeactivate', 'onPostDeactivate']);
+  });
+});


### PR DESCRIPTION
Fixes #1689

- Add delayReturnFocus as a non-breaking option (default true) to control whether return focus and onPostDeactivate are deferred by one frame.
- Update docs and typings to describe timing interplay with activation/deactivation gating options.
- Add lifecycle unit tests covering stacked-trap ordering and checkCanReturnFocus interoperability.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain stated browser compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Includes updated docs demo bundle if source/docs code was changed (run `npm run demo-bundle` in your branch and include the `/docs/demo-bundle.js` file that gets generated in your PR).
- Unit test coverage added/updated.
- E2E (i.e. demos) test coverage added/updated.
  - ⚠️ Non-covered demos (look for `// TEST MANUALLY` comments [here](https://github.com/focus-trap/focus-trap/blob/master/docs/js/index.js)) that can't be fully tested in Cypress have been __manually__ verified.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delayReturnFocus option (default: true) to control whether focus return and onPostDeactivate are deferred by one animation frame.

* **Documentation**
  * Clarified lifecycle callback timing and interactions between delayInitialFocus, checkCanFocusTrap, checkCanReturnFocus, and delayReturnFocus.

* **Tests**
  * Added lifecycle timing test suite covering stacked traps, delayReturnFocus behavior, and checkCanReturnFocus timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->