### PR TITLE
fix: ensure parent trap resumes using innermost active element in shadow DOM

### DIFF
--- a/.changeset/wicked-windows-retire.md
+++ b/.changeset/wicked-windows-retire.md
@@ -1,0 +1,5 @@
+---
+'focus-trap': patch
+---
+
+Improve shadow DOM focus handling for nested traps.

--- a/.changeset/wicked-windows-retire.md
+++ b/.changeset/wicked-windows-retire.md
@@ -2,4 +2,4 @@
 'focus-trap': patch
 ---
 
-Improve shadow DOM focus handling for nested traps.
+Improve shadow DOM focus handling for nested traps by ensuring a parent trap resumes using the innermost active element ([#1885](https://github.com/focus-trap/focus-trap/issues/1885))

--- a/index.js
+++ b/index.js
@@ -307,7 +307,7 @@ const createFocusTrap = function (elements, userOptions) {
    *
    * @param {Document | ShadowRoot} el
    *
-  * @returns {HTMLElement|null} The element that currently has the focus. `null` if a focused element isn't found.
+   * @returns {HTMLElement|null} The element that currently has the focus. `null` if a focused element isn't found.
    **/
   const getActiveElement = function (el) {
     const activeElement = el.activeElement;

--- a/index.js
+++ b/index.js
@@ -313,7 +313,7 @@ const createFocusTrap = function (elements, userOptions) {
     const activeElement = el.activeElement;
 
     if (!activeElement) {
-      return;
+      return null;
     }
 
     if (

--- a/index.js
+++ b/index.js
@@ -301,6 +301,31 @@ const createFocusTrap = function (elements, userOptions) {
     return node;
   };
 
+  /**
+   * Gets the current activeElement. If it's a web-component and has open shadow-root
+   * it will recursively search inside shadow roots for the "true" activeElement.
+   *
+   * @param {Document | ShadowRoot} el
+   *
+   * @returns {HTMLElement} The element that currently has the focus
+   **/
+  const getActiveElement = function (el) {
+    const activeElement = el.activeElement;
+
+    if (!activeElement) {
+      return;
+    }
+
+    if (
+      activeElement.shadowRoot &&
+      activeElement.shadowRoot.activeElement !== null
+    ) {
+      return getActiveElement(activeElement.shadowRoot);
+    }
+
+    return activeElement;
+  };
+
   const getInitialFocusNode = function () {
     let node = getNodeForOption('initialFocus', { hasFallback: true });
 
@@ -313,9 +338,11 @@ const createFocusTrap = function (elements, userOptions) {
       node === undefined ||
       (node && !isFocusable(node, config.tabbableOptions))
     ) {
+      const activeElement = getActiveElement(doc);
+
       // option not specified nor focusable: use fallback options
-      if (findContainerIndex(doc.activeElement) >= 0) {
-        node = doc.activeElement;
+      if (findContainerIndex(activeElement) >= 0) {
+        node = activeElement;
       } else {
         const firstTabbableGroup = state.tabbableGroups[0];
         const firstTabbableNode =
@@ -455,31 +482,6 @@ const createFocusTrap = function (elements, userOptions) {
         "At least one node with a positive tabindex was found in one of your focus-trap's multiple containers. Positive tabindexes are only supported in single-container focus-traps."
       );
     }
-  };
-
-  /**
-   * Gets the current activeElement. If it's a web-component and has open shadow-root
-   * it will recursively search inside shadow roots for the "true" activeElement.
-   *
-   * @param {Document | ShadowRoot} el
-   *
-   * @returns {HTMLElement} The element that currently has the focus
-   **/
-  const getActiveElement = function (el) {
-    const activeElement = el.activeElement;
-
-    if (!activeElement) {
-      return;
-    }
-
-    if (
-      activeElement.shadowRoot &&
-      activeElement.shadowRoot.activeElement !== null
-    ) {
-      return getActiveElement(activeElement.shadowRoot);
-    }
-
-    return activeElement;
   };
 
   const tryFocus = function (node) {

--- a/index.js
+++ b/index.js
@@ -307,7 +307,7 @@ const createFocusTrap = function (elements, userOptions) {
    *
    * @param {Document | ShadowRoot} el
    *
-   * @returns {HTMLElement} The element that currently has the focus
+  * @returns {HTMLElement|null} The element that currently has the focus. `null` if a focused element isn't found.
    **/
   const getActiveElement = function (el) {
     const activeElement = el.activeElement;

--- a/test/fixtures/dom/shadowDom.html
+++ b/test/fixtures/dom/shadowDom.html
@@ -1,0 +1,27 @@
+<!--
+NOTE: script blocks are always executed AFTER the HTML is loaded no matter the
+ node order here
+-->
+
+<div id="fixture">
+  <test-case></test-case>
+
+  <template id="testCaseTemplate">
+    <test-dialog id="dialog">
+      <test-picker id="picker"></test-picker>
+      <input id="input" placeholder="2. Click here after opening the picker, focus should stay here" />
+    </test-dialog>
+  </template>
+
+  <template id="testDialogTemplate">
+    <button id="closeButton">x</button>
+    <slot></slot>
+  </template>
+
+  <template id="testPickerTemplate">
+    <button id="trigger" placeholder="1. Click me to open picker options and activate nested focus trap" />
+    <div id="optionsContainer">
+      <input id="input" placeholder="Fake focusable picker options" />
+    </div>
+  </template>
+</div>

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -25,6 +25,11 @@ const domFixtures = {
       }
     ),
   },
+  shadowDom: {
+    html: fs.readFileSync(path.resolve(__dirname, './dom/shadowDom.html'), {
+      encoding: 'utf-8',
+    }),
+  },
 };
 
 module.exports = {

--- a/test/suites/shadowDom.test.js
+++ b/test/suites/shadowDom.test.js
@@ -1,0 +1,160 @@
+import { waitFor } from '@testing-library/dom';
+import { userEvent } from '@testing-library/user-event';
+import { createFocusTrap } from '../../index';
+
+// NOTE: in jest, the only display check that's expected to work is 'none' because
+//  jsDom doesn't support the APIs needed to make the other modes work
+const tabbableOptions = {
+  displayCheck: 'none',
+  getShadowRoot: true,
+};
+
+function getInnermostActiveElement(root) {
+  const activeElement = root.activeElement;
+  if (!activeElement) {
+    return null;
+  }
+
+  if (activeElement.shadowRoot?.activeElement) {
+    return getInnermostActiveElement(activeElement.shadowRoot);
+  }
+
+  return activeElement;
+}
+
+function defineTestCustomElements(container) {
+  function updateTrap(trap, isOpen) {
+    if (isOpen) {
+      trap.activate();
+    } else {
+      trap.deactivate();
+    }
+  }
+
+  class TestCase extends HTMLElement {
+    constructor() {
+      super();
+      const template = container.querySelector('#testCaseTemplate');
+      const shadowRoot = this.attachShadow({ mode: 'open' });
+      shadowRoot.append(document.importNode(template.content, true));
+    }
+  }
+
+  customElements.define('test-case', TestCase);
+
+  class CustomDialog extends HTMLElement {
+    static observedAttributes = ['open'];
+
+    constructor() {
+      super();
+
+      const template = container.querySelector('#testDialogTemplate');
+      const shadowRoot = this.attachShadow({ mode: 'open' });
+      shadowRoot.append(document.importNode(template.content, true));
+
+      this.focusTrap = createFocusTrap(this, {
+        tabbableOptions: {
+          ...tabbableOptions,
+        },
+      });
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+      if (name === 'open') {
+        updateTrap(this.focusTrap, newValue !== null);
+      }
+    }
+  }
+
+  customElements.define('test-dialog', CustomDialog);
+
+  class CustomPicker extends HTMLElement {
+    static observedAttributes = ['open'];
+
+    constructor() {
+      super();
+
+      const template = container.querySelector('#testPickerTemplate');
+      const shadowRoot = this.attachShadow({ mode: 'open' });
+      shadowRoot.append(document.importNode(template.content, true));
+
+      this.trigger = shadowRoot.querySelector('#trigger');
+      this.optionsContainer = shadowRoot.querySelector('#optionsContainer');
+
+      this.focusTrap = createFocusTrap(this.optionsContainer, {
+        clickOutsideDeactivates: true,
+        tabbableOptions: {
+          ...tabbableOptions,
+        },
+        setReturnFocus: false,
+        onDeactivate: () => {
+          this.removeAttribute('open');
+        },
+      });
+    }
+
+    connectedCallback() {
+      this.trigger.addEventListener('click', () => {
+        this.toggleAttribute('open');
+      });
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+      if (name === 'open') {
+        updateTrap(this.focusTrap, newValue !== null);
+      }
+    }
+  }
+
+  customElements.define('test-picker', CustomPicker);
+}
+
+describe('shadow DOM', () => {
+  it('should use innermost active element when parent trap resumes in shadow DOM', async () => {
+    /** @type {import('../tools/testingUtility.js').RenderResults} */
+    const { containerEl } = renderFixture('shadowDom');
+    defineTestCustomElements(containerEl);
+
+    const testCase = containerEl.querySelector('test-case');
+
+    const testCaseInput = testCase.shadowRoot.querySelector('#input');
+    const dialog = testCase.shadowRoot.querySelector('#dialog');
+    const dialogCloseButton =
+      dialog.shadowRoot.querySelector('#closeButton');
+    const picker = testCase.shadowRoot.querySelector('#picker');
+    const pickerTrigger = picker.shadowRoot.querySelector('#trigger');
+    const pickerInput = picker.shadowRoot.querySelector('#input');
+
+    expect(document.body).toHaveFocus();
+
+    dialog.toggleAttribute('open');
+
+    await waitFor(() => expect(dialog.focusTrap.active).toBe(true));
+
+    await waitFor(() =>
+      expect(getInnermostActiveElement(document)).toBe(dialogCloseButton)
+    );
+
+    await userEvent.click(pickerTrigger);
+
+    await waitFor(() => {
+      expect(picker.focusTrap.active).toBe(true);
+      expect(dialog.focusTrap.paused).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(getInnermostActiveElement(document)).toBe(pickerInput);
+    });
+
+    await userEvent.click(testCaseInput);
+
+    await waitFor(() => {
+      expect(picker.focusTrap.active).toBe(false);
+      expect(dialog.focusTrap.paused).toBe(false);
+    });
+
+    await waitFor(() => {
+      expect(getInnermostActiveElement(document)).toBe(testCaseInput);
+    });
+  });
+});

--- a/test/suites/shadowDom.test.js
+++ b/test/suites/shadowDom.test.js
@@ -119,8 +119,7 @@ describe('shadow DOM', () => {
 
     const testCaseInput = testCase.shadowRoot.querySelector('#input');
     const dialog = testCase.shadowRoot.querySelector('#dialog');
-    const dialogCloseButton =
-      dialog.shadowRoot.querySelector('#closeButton');
+    const dialogCloseButton = dialog.shadowRoot.querySelector('#closeButton');
     const picker = testCase.shadowRoot.querySelector('#picker');
     const pickerTrigger = picker.shadowRoot.querySelector('#trigger');
     const pickerInput = picker.shadowRoot.querySelector('#input');


### PR DESCRIPTION
Fixes: #1885

## Summary

Fix nested shadow DOM trap handoff by resolving initial focus from the innermost active element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the currently focused element across nested Shadow DOM so focus traps resume and behave correctly with custom elements.

* **New Features**
  * Focus handling now tracks the innermost active element through nested shadow roots for more reliable focus restoration and re-focus guards.

* **Tests**
  * Added shadow DOM test suite and fixtures covering nested traps, custom elements, and complex focus interactions.

* **Chores**
  * Updated release metadata for a patch publish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->